### PR TITLE
fix: break completion loop when teammates and lead ping-pong after task done

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -41,11 +41,26 @@ export function handleSessionStatusEvent(
       "UPDATE team_member SET status = ?, execution_status = 'idle', time_updated = ? WHERE team_id = ? AND name = ?",
       [newStatus, Date.now(), entry.teamId, entry.memberName]
     )
+    // Mark teammate as having reported if they sent at least one message to lead (issue #3).
+    // Set on busy→ready transition so Q&A messages during work don't prematurely block delivery.
+    if (member.status === "busy" && newStatus === "ready") {
+      const leadMsgCount = (db.query(
+        "SELECT COUNT(*) as c FROM team_message WHERE team_id = ? AND from_name = ? AND to_name = 'lead'"
+      ).get(entry.teamId, entry.memberName) as { c: number }).c
+      if (leadMsgCount > 0) {
+        db.run(
+          "UPDATE team_member SET reported_to_lead = 1 WHERE team_id = ? AND name = ?",
+          [entry.teamId, entry.memberName]
+        )
+      }
+    }
     return { memberName: entry.memberName, teamId: entry.teamId, from: member.status, to: newStatus }
   } else if (status === "busy") {
     if (member.status === "ready" || member.status === "error") {
+      // Reset reported_to_lead so re-activated teammates can receive messages again (issue #3).
+      // INVARIANT: every promptAsync delivery path must check hasReportedCompletion() to prevent loops.
       db.run(
-        "UPDATE team_member SET status = 'busy', execution_status = 'running', time_updated = ? WHERE team_id = ? AND name = ?",
+        "UPDATE team_member SET status = 'busy', execution_status = 'running', reported_to_lead = 0, time_updated = ? WHERE team_id = ? AND name = ?",
         [Date.now(), entry.teamId, entry.memberName]
       )
       return { memberName: entry.memberName, teamId: entry.teamId, from: member.status, to: "busy" }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { MemberRegistry, DescendantTracker } from "./state"
 import { isWorktreeInstance } from "./util"
 import { handleSessionStatusEvent, handleSessionCreatedEvent, checkToolIsolation, shouldNudgeIdleMember } from "./hooks"
 import { notifyTeamEvent, notifyWorkingProgress } from "./notify"
-import { sendMessage } from "./messaging"
+import { sendMessage, hasReportedCompletion } from "./messaging"
 import { buildLeadSystemPrompt, buildTeammateSystemPrompt, buildTeamCompactionContext } from "./system-prompt"
 import { log, initLog } from "./log"
 import { findTeamBySession } from "./types"
@@ -58,6 +58,8 @@ const plugin: Plugin = async (input) => {
   const tracker = new DescendantTracker()
   const nudgedMembers = new Set<string>()
   const progressTracker = new ProgressTracker()
+  const wakeLeadTimestamps = new Map<string, number>()
+  const WAKE_LEAD_COOLDOWN_MS = 5000
 
   // Extract the working HeyAPI transport from the plugin-provided v1 client and pass it
   // to the v2 OpencodeClient. The plugin framework provides a v1 client which stores its
@@ -176,8 +178,9 @@ const plugin: Plugin = async (input) => {
             }
 
             // Nudge teammate if they went idle without reporting to the lead (once only)
+            // Skip if they already reported completion (issue #3 — prevents re-waking completed teammates)
             const nudgeKey = `${transition.teamId}:${transition.memberName}`
-            if (!nudgedMembers.has(nudgeKey) && shouldNudgeIdleMember(db, transition.teamId, transition.memberName)) {
+            if (!nudgedMembers.has(nudgeKey) && shouldNudgeIdleMember(db, transition.teamId, transition.memberName) && !hasReportedCompletion(db, transition.teamId, transition.memberName)) {
               nudgedMembers.add(nudgeKey)
               log(`nudge:idle-without-report name=${transition.memberName}`)
               client.session.promptAsync({
@@ -232,7 +235,13 @@ const plugin: Plugin = async (input) => {
           const team = db.query("SELECT id FROM team WHERE lead_session_id = ? AND status = 'active'").get(sessionID) as { id: string } | null
           if (team) {
             const pending = db.query("SELECT COUNT(*) as c FROM team_message WHERE team_id = ? AND to_name = 'lead' AND delivered = 0").get(team.id) as { c: number }
-            if (pending.c > 0) {
+            // Skip wake if all teammates are done or if we woke recently (issue #3 — breaks completion loop)
+            const allDone = (db.query(
+              "SELECT COUNT(*) as c FROM team_member WHERE team_id = ? AND status NOT IN ('ready', 'shutdown', 'error')"
+            ).get(team.id) as { c: number }).c === 0
+            const lastWake = wakeLeadTimestamps.get(team.id) ?? 0
+            if (pending.c > 0 && !allDone && Date.now() - lastWake > WAKE_LEAD_COOLDOWN_MS) {
+              wakeLeadTimestamps.set(team.id, Date.now())
               log(`wake-lead: ${pending.c} pending messages, sending promptAsync`)
               client.session.promptAsync({
                 sessionID,
@@ -250,7 +259,7 @@ const plugin: Plugin = async (input) => {
              JOIN team t ON tm.team_id = t.id
              WHERE tm.session_id = ? AND t.status = 'active'`
           ).get(sessionID) as { team_id: string; name: string } | null
-          if (member) {
+          if (member && !hasReportedCompletion(db, member.team_id, member.name)) {
             const staleThreshold = Date.now() - 5000
             const peerMsgs = db.query(
               "SELECT COUNT(*) as c FROM team_message WHERE team_id = ? AND to_name = ? AND delivered = 0 AND time_created < ?"

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -76,3 +76,14 @@ export function getUndeliveredMessages(db: Database, teamId: string): MessageRow
 export function markDelivered(db: Database, messageId: string): void {
   db.run("UPDATE team_message SET delivered = 1 WHERE id = ?", [messageId])
 }
+
+/**
+ * Check if a teammate has reported completion to the lead.
+ * Returns true if the reported_to_lead flag is set on the member.
+ */
+export function hasReportedCompletion(db: Database, teamId: string, memberName: string): boolean {
+  const row = db.query(
+    "SELECT reported_to_lead FROM team_member WHERE team_id = ? AND name = ?"
+  ).get(teamId, memberName) as { reported_to_lead: number } | null
+  return row?.reported_to_lead === 1
+}

--- a/src/recovery.ts
+++ b/src/recovery.ts
@@ -1,7 +1,7 @@
 import type { Database } from "bun:sqlite"
 import type { PluginClient } from "./types"
 import type { MemberRegistry } from "./state"
-import { getUndeliveredMessages, markDelivered } from "./messaging"
+import { getUndeliveredMessages, markDelivered, hasReportedCompletion } from "./messaging"
 import { preserveBranch, preservedBranchName } from "./tools/merge-helper"
 import { log } from "./log"
 
@@ -122,6 +122,12 @@ export async function recoverUndeliveredMessages(
       }
 
       if (!recipientSessionId) continue
+
+      // Skip delivery to teammates who have already reported completion (issue #3)
+      if (hasReportedCompletion(db, team.id, msg.to_name!)) {
+        markDelivered(db, msg.id)
+        continue
+      }
 
       try {
         await client.session.promptAsync({

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -80,6 +80,8 @@ export const MIGRATIONS: string[] = [
   `ALTER TABLE team ADD COLUMN lead_agent TEXT;`,
   // Migration 6: Track workspace ID for worktree-session binding
   `ALTER TABLE team_member ADD COLUMN workspace_id TEXT;`,
+  // Migration 7: Track whether teammate has reported to lead (completion loop prevention, issue #3)
+  `ALTER TABLE team_member ADD COLUMN reported_to_lead INTEGER NOT NULL DEFAULT 0;`,
 ]
 
 /**

--- a/src/tools/team-broadcast.ts
+++ b/src/tools/team-broadcast.ts
@@ -1,6 +1,6 @@
 import type { ToolDeps } from "../types"
 import { requireTeamMember } from "./shared"
-import { broadcastMessage, markDelivered } from "../messaging"
+import { broadcastMessage, markDelivered, hasReportedCompletion } from "../messaging"
 import { log } from "../log"
 
 /**
@@ -40,8 +40,14 @@ export async function executeTeamBroadcast(
   }
 
   // Fire-and-forget: deliver to all recipients. Message is already persisted in DB.
+  // Skip completed teammates to prevent re-waking them (issue #3).
   let delivered = 0
+  let skipped = 0
   for (const recipient of recipients) {
+    if (recipient.name !== "lead" && hasReportedCompletion(deps.db, teamInfo.teamId, recipient.name)) {
+      skipped++
+      continue
+    }
     deps.client.session.promptAsync({
       sessionID: recipient.sessionId,
       parts: [{ type: "text", text: `[Team broadcast from ${senderName}]: ${args.text}` }],
@@ -53,5 +59,6 @@ export async function executeTeamBroadcast(
     })
   }
 
-  return `Broadcast sent to ${recipients.length} recipient${recipients.length !== 1 ? "s" : ""}.`
+  const sent = recipients.length - skipped
+  return `Broadcast sent to ${sent} recipient${sent !== 1 ? "s" : ""}.`
 }

--- a/src/tools/team-message.ts
+++ b/src/tools/team-message.ts
@@ -1,7 +1,7 @@
 import type { ToolDeps } from "../types"
 import { resolveRecipientSession } from "../types"
 import { requireTeamMember } from "./shared"
-import { sendMessage, markDelivered } from "../messaging"
+import { sendMessage, markDelivered, hasReportedCompletion } from "../messaging"
 import { log } from "../log"
 
 /**
@@ -88,6 +88,11 @@ export async function executeTeamMessage(
       log(`team_message:wake-lead:failed from=${senderName} err=${err instanceof Error ? err.message : String(err)}`)
     })
     return `Message sent to ${args.to}.`
+  }
+
+  // Guard: skip promptAsync delivery to teammates who have already reported completion (issue #3)
+  if (hasReportedCompletion(deps.db, teamInfo.teamId, args.to)) {
+    return `Message stored for ${args.to} (teammate has completed their task — message will not wake them).`
   }
 
   // For member-to-member messages, fire-and-forget delivery is safe.

--- a/test/completion-loop.test.ts
+++ b/test/completion-loop.test.ts
@@ -1,0 +1,160 @@
+import { describe, test, expect, beforeEach } from "bun:test"
+import { setupDeps, insertTeam, insertMember } from "./helpers"
+import { executeTeamCreate } from "../src/tools/team-create"
+import { executeTeamSpawn } from "../src/tools/team-spawn"
+import { executeTeamMessage } from "../src/tools/team-message"
+import { handleSessionStatusEvent } from "../src/hooks"
+import { hasReportedCompletion } from "../src/messaging"
+import { sendMessage } from "../src/messaging"
+
+type Deps = ReturnType<typeof setupDeps>
+
+describe("issue #3: completion loop prevention", () => {
+  let deps: Deps
+  const leadSession = "lead-sess"
+
+  beforeEach(() => {
+    deps = setupDeps()
+  })
+
+  /** Helper: spawn a teammate, have them message lead, then transition busy→ready. */
+  async function spawnAndComplete(teamName: string, memberName: string): Promise<{ teamId: string; memberSession: string }> {
+    await executeTeamCreate(deps, { name: teamName }, leadSession)
+    const team = deps.db.query("SELECT id FROM team WHERE name = ?").get(teamName) as { id: string }
+    await executeTeamSpawn(deps, { name: memberName, agent: "build", prompt: "task", worktree: false }, leadSession)
+    const memberSession = (deps.db.query("SELECT session_id FROM team_member WHERE name = ?").get(memberName) as { session_id: string }).session_id
+
+    // Teammate messages lead
+    await executeTeamMessage(deps, { to: "lead", text: "here are my findings" }, memberSession)
+
+    // Simulate busy→ready transition (teammate finished work)
+    deps.db.run("UPDATE team_member SET status = 'busy' WHERE team_id = ? AND name = ?", [team.id, memberName])
+    handleSessionStatusEvent(deps.db, deps.registry, memberSession, "idle")
+
+    return { teamId: team.id, memberSession }
+  }
+
+  test("hasReportedCompletion is false after messaging lead but BEFORE going idle", async () => {
+    await executeTeamCreate(deps, { name: "report-team" }, leadSession)
+    const team = deps.db.query("SELECT id FROM team WHERE name = 'report-team'").get() as { id: string }
+    await executeTeamSpawn(deps, { name: "alice", agent: "build", prompt: "task", worktree: false }, leadSession)
+    const aliceSession = (deps.db.query("SELECT session_id FROM team_member WHERE name = 'alice'").get() as { session_id: string }).session_id
+
+    expect(hasReportedCompletion(deps.db, team.id, "alice")).toBe(false)
+
+    // Alice messages lead — flag should NOT be set yet (she's still working)
+    await executeTeamMessage(deps, { to: "lead", text: "done with my task" }, aliceSession)
+    expect(hasReportedCompletion(deps.db, team.id, "alice")).toBe(false)
+
+    // Alice goes idle (busy→ready) — NOW the flag should be set
+    deps.db.run("UPDATE team_member SET status = 'busy' WHERE team_id = ? AND name = 'alice'", [team.id])
+    handleSessionStatusEvent(deps.db, deps.registry, aliceSession, "idle")
+    expect(hasReportedCompletion(deps.db, team.id, "alice")).toBe(true)
+  })
+
+  test("hasReportedCompletion stays false if teammate goes idle WITHOUT messaging lead", async () => {
+    await executeTeamCreate(deps, { name: "no-msg-team" }, leadSession)
+    const team = deps.db.query("SELECT id FROM team WHERE name = 'no-msg-team'").get() as { id: string }
+    await executeTeamSpawn(deps, { name: "bob", agent: "build", prompt: "task", worktree: false }, leadSession)
+    const bobSession = (deps.db.query("SELECT session_id FROM team_member WHERE name = 'bob'").get() as { session_id: string }).session_id
+
+    // Bob goes idle without ever messaging lead
+    deps.db.run("UPDATE team_member SET status = 'busy' WHERE team_id = ? AND name = 'bob'", [team.id])
+    handleSessionStatusEvent(deps.db, deps.registry, bobSession, "idle")
+    expect(hasReportedCompletion(deps.db, team.id, "bob")).toBe(false)
+  })
+
+  test("messages to completed teammates are stored but NOT pushed via promptAsync", async () => {
+    const { teamId, memberSession } = await spawnAndComplete("guard-team", "charlie")
+    deps.client.calls.length = 0
+
+    // Lead sends a reply (this is what Kimi K2.6 does — courtesy replies)
+    const result = await executeTeamMessage(deps, { to: "charlie", text: "thanks charlie!" }, leadSession)
+
+    // Message IS stored in DB
+    const msg = deps.db.query("SELECT content FROM team_message WHERE team_id = ? AND to_name = 'charlie' AND from_name = 'lead'").get(teamId) as { content: string } | null
+    expect(msg).toBeTruthy()
+    expect(msg!.content).toBe("thanks charlie!")
+
+    // But promptAsync was NOT called to deliver it
+    const promptCalls = deps.client.calls.filter(c => c.method === "session.promptAsync")
+    expect(promptCalls).toHaveLength(0)
+
+    // Return value warns the lead
+    expect(result).toContain("completed")
+  })
+
+  test("wake-lead skips when all teammates are ready/shutdown", async () => {
+    const { teamId } = await spawnAndComplete("done-team", "dave")
+
+    // Insert another undelivered message to lead (simulating the loop)
+    sendMessage(deps.db, { teamId, from: "dave", to: "lead", content: "duplicate" })
+
+    // All members should be in a terminal state
+    const activeBusy = deps.db.query(
+      "SELECT COUNT(*) as c FROM team_member WHERE team_id = ? AND status NOT IN ('ready', 'shutdown', 'error')"
+    ).get(teamId) as { c: number }
+    expect(activeBusy.c).toBe(0)
+  })
+
+  test("peer-flush skips for completed teammates", async () => {
+    const { teamId } = await spawnAndComplete("flush-team", "eve")
+
+    expect(hasReportedCompletion(deps.db, teamId, "eve")).toBe(true)
+
+    // Insert a stale peer message addressed to eve (simulating the loop)
+    deps.db.run(
+      "INSERT INTO team_message (id, team_id, from_name, to_name, content, delivered, time_created) VALUES (?, ?, 'lead', 'eve', 'follow up', 0, ?)",
+      ["msg-stale", teamId, Date.now() - 10_000]
+    )
+
+    const reported = deps.db.query("SELECT reported_to_lead FROM team_member WHERE team_id = ? AND name = 'eve'").get(teamId) as { reported_to_lead: number }
+    expect(reported.reported_to_lead).toBe(1)
+  })
+
+  test("full ping-pong regression: promptAsync calls are bounded after completion", async () => {
+    const { teamId, memberSession } = await spawnAndComplete("loop-team", "frank")
+
+    // Reset call log — everything after this should be bounded
+    deps.client.calls.length = 0
+
+    // Simulate the ping-pong loop that Kimi K2.6 triggers:
+    const reply1 = await executeTeamMessage(deps, { to: "frank", text: "thanks for the report" }, leadSession)
+    const reply2 = await executeTeamMessage(deps, { to: "frank", text: "anything else?" }, leadSession)
+
+    // Both replies should be stored but NOT delivered
+    expect(reply1).toContain("completed")
+    expect(reply2).toContain("completed")
+
+    // Zero promptAsync calls to frank's session after he reported
+    const frankCalls = deps.client.calls.filter(c => {
+      if (c.method !== "session.promptAsync") return false
+      const args = c.args[0] as { sessionID: string }
+      return args.sessionID === memberSession
+    })
+    expect(frankCalls).toHaveLength(0)
+  })
+
+  test("teammate can still receive messages BEFORE going idle (Q&A works)", async () => {
+    await executeTeamCreate(deps, { name: "qa-team" }, leadSession)
+    const team = deps.db.query("SELECT id FROM team WHERE name = 'qa-team'").get() as { id: string }
+    await executeTeamSpawn(deps, { name: "grace", agent: "build", prompt: "task", worktree: false }, leadSession)
+    const graceSession = (deps.db.query("SELECT session_id FROM team_member WHERE name = 'grace'").get() as { session_id: string }).session_id
+
+    // Grace asks lead a question (messages lead, but is still busy)
+    await executeTeamMessage(deps, { to: "lead", text: "I have a question about the API" }, graceSession)
+
+    // Grace is NOT marked as completed yet (still busy)
+    expect(hasReportedCompletion(deps.db, team.id, "grace")).toBe(false)
+
+    deps.client.calls.length = 0
+
+    // Lead answers — this SHOULD be delivered (grace hasn't completed)
+    const result = await executeTeamMessage(deps, { to: "grace", text: "use the v2 endpoint" }, leadSession)
+
+    // Message was delivered via promptAsync (not blocked)
+    expect(result).toBe("Message sent to grace.")
+    const promptCalls = deps.client.calls.filter(c => c.method === "session.promptAsync")
+    expect(promptCalls).toHaveLength(1)
+  })
+})

--- a/test/stress.test.ts
+++ b/test/stress.test.ts
@@ -16,7 +16,8 @@ import { buildLeadSystemPrompt, buildTeamCompactionContext } from "../src/system
 import { ProgressTracker } from "../src/progress"
 import { Watchdog } from "../src/watchdog"
 import { loadConfig, DEFAULT_CONFIG } from "../src/config"
-import { sendMessage } from "../src/messaging"
+import { sendMessage, hasReportedCompletion } from "../src/messaging"
+import { handleSessionStatusEvent } from "../src/hooks"
 import type { ToolDeps } from "../src/types"
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs"
 import path from "node:path"
@@ -690,5 +691,109 @@ describe("stress: model resolution", () => {
     const promptCalls = deps.client.calls.filter(c => c.method === "session.promptAsync")
     const model = (promptCalls[0]!.args[0] as { model?: unknown }).model
     expect(model).toBeUndefined()
+  })
+})
+
+// ─── Completion loop stress (issue #3) ───
+
+describe("stress: completion loop prevention (issue #3)", () => {
+  let deps: Deps
+  const lead = "lead-sess"
+
+  beforeEach(() => {
+    deps = setupDeps()
+    spawnFailures.clear()
+  })
+
+  test("full lifecycle: 3 teammates complete → lead replies to all → no infinite loop", async () => {
+    // 1. Create team and spawn 3 teammates
+    await executeTeamCreate(deps, { name: "loop-stress" }, lead)
+    const teamId = getTeamId(deps, "loop-stress")
+    for (const name of ["alice", "bob", "carol"]) {
+      await executeTeamSpawn(deps, { name, agent: "build", prompt: `Task for ${name}`, worktree: false }, lead)
+    }
+
+    const aliceSess = getSession(deps, "alice")
+    const bobSess = getSession(deps, "bob")
+    const carolSess = getSession(deps, "carol")
+
+    // 2. All three report to lead
+    await executeTeamMessage(deps, { to: "lead", text: "alice done" }, aliceSess)
+    await executeTeamMessage(deps, { to: "lead", text: "bob done" }, bobSess)
+    await executeTeamMessage(deps, { to: "lead", text: "carol done" }, carolSess)
+
+    // 3. All three go idle (busy→ready) — sets reported_to_lead
+    for (const sess of [aliceSess, bobSess, carolSess]) {
+      deps.db.run("UPDATE team_member SET status = 'busy' WHERE session_id = ?", [sess])
+      handleSessionStatusEvent(deps.db, deps.registry, sess, "idle")
+    }
+
+    expect(hasReportedCompletion(deps.db, teamId, "alice")).toBe(true)
+    expect(hasReportedCompletion(deps.db, teamId, "bob")).toBe(true)
+    expect(hasReportedCompletion(deps.db, teamId, "carol")).toBe(true)
+
+    // 4. Reset call log — simulate the Kimi K2.6 ping-pong
+    deps.client.calls.length = 0
+
+    // Lead sends courtesy replies to all three (this is what chatty models do)
+    for (const name of ["alice", "bob", "carol"]) {
+      const result = await executeTeamMessage(deps, { to: name, text: `thanks ${name}!` }, lead)
+      expect(result).toContain("completed")
+    }
+
+    // Lead broadcasts a follow-up
+    const { executeTeamBroadcast } = await import("../src/tools/team-broadcast")
+    const broadcastResult = await executeTeamBroadcast(deps, { text: "great work everyone" }, lead)
+
+    // 5. Verify: ZERO promptAsync calls to any teammate session
+    const teammateSessions = new Set([aliceSess, bobSess, carolSess])
+    const teammateWakes = deps.client.calls.filter(c => {
+      if (c.method !== "session.promptAsync") return false
+      const args = c.args[0] as { sessionID: string }
+      return teammateSessions.has(args.sessionID)
+    })
+    expect(teammateWakes).toHaveLength(0)
+
+    // 6. Verify: messages ARE stored in DB (not lost, just not pushed)
+    const storedMsgs = deps.db.query(
+      "SELECT COUNT(*) as c FROM team_message WHERE team_id = ? AND from_name = 'lead'"
+    ).get(teamId) as { c: number }
+    expect(storedMsgs.c).toBeGreaterThanOrEqual(3)
+
+    // 7. Shutdown and cleanup still works
+    for (const name of ["alice", "bob", "carol"]) {
+      await executeTeamShutdown(deps, { member: name, force: true }, lead)
+    }
+    const result = await executeTeamCleanup(deps, { force: false }, lead, undefined, noopMerge, noopDelete, false)
+    expect(result).toContain("cleaned up")
+  })
+
+  test("re-activated teammate can receive messages again", async () => {
+    await executeTeamCreate(deps, { name: "reactivate" }, lead)
+    const teamId = getTeamId(deps, "reactivate")
+    await executeTeamSpawn(deps, { name: "dave", agent: "build", prompt: "task", worktree: false }, lead)
+    const daveSess = getSession(deps, "dave")
+
+    // Dave reports and goes idle
+    await executeTeamMessage(deps, { to: "lead", text: "first pass done" }, daveSess)
+    deps.db.run("UPDATE team_member SET status = 'busy' WHERE session_id = ?", [daveSess])
+    handleSessionStatusEvent(deps.db, deps.registry, daveSess, "idle")
+    expect(hasReportedCompletion(deps.db, teamId, "dave")).toBe(true)
+
+    // Lead's reply is blocked (dave completed)
+    deps.client.calls.length = 0
+    const blocked = await executeTeamMessage(deps, { to: "dave", text: "blocked reply" }, lead)
+    expect(blocked).toContain("completed")
+
+    // Dave gets re-activated (goes busy again) — flag resets
+    handleSessionStatusEvent(deps.db, deps.registry, daveSess, "busy")
+    expect(hasReportedCompletion(deps.db, teamId, "dave")).toBe(false)
+
+    // Now lead's message goes through
+    deps.client.calls.length = 0
+    const delivered = await executeTeamMessage(deps, { to: "dave", text: "do one more thing" }, lead)
+    expect(delivered).toBe("Message sent to dave.")
+    const promptCalls = deps.client.calls.filter(c => c.method === "session.promptAsync")
+    expect(promptCalls).toHaveLength(1)
   })
 })


### PR DESCRIPTION
Fixes #3

## What happened

Some models (Kimi K2.6 in the report) send courtesy replies after a teammate reports completion. The lead replies back, which wakes the teammate, who responds again, and the cycle never stops.

## Root cause

Three interacting feedback loops in the message delivery system:
- Wake-lead fires `promptAsync` every time the lead goes idle with undelivered messages
- Peer-flush re-delivers messages to teammates that just went idle
- Nudge wakes teammates who went idle without reporting

With models that don't respect "STOP" instructions, these mechanisms keep both sides alive indefinitely.

## Fix

Add a `reported_to_lead` flag on `team_member` (migration 7). Set it when a teammate transitions busy->ready after having sent at least one message to the lead. Then check it at every `promptAsync` delivery point:

- `team_message` - skip delivery to completed teammates, return warning to lead
- `team_broadcast` - skip completed teammates in delivery loop
- `recovery.ts` - skip redelivery to completed teammates
- `index.ts` - skip peer-flush and nudge for completed teammates
- `index.ts` - add wake-lead cooldown (5s dedup) + all-done check

The flag resets on ready->busy so re-activated teammates can still receive messages. Q&A during active work is unaffected since the flag only sets on the idle transition.

## Tests

7 new tests in `test/completion-loop.test.ts`:
- Flag lifecycle (set on idle, not on message send)
- Flag stays false if teammate never messaged lead
- Delivery suppression after completion
- Wake-lead skip when all done
- Peer-flush skip for completed teammates
- Full ping-pong regression (bounded promptAsync calls)
- Q&A still works during active work

All 490 tests pass. Typecheck clean. Build clean.