### PR TITLE
Enforce branch name prefixes

### DIFF
--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -1,0 +1,24 @@
+name: Branch name
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch prefix
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          case "$HEAD_REF" in
+            bugfix/*|feature/*|chore/*)
+              exit 0
+              ;;
+            *)
+              echo "Branch names must start with bugfix/, feature/, or chore/."
+              echo "Examples: feature/add-widget, bugfix/login-timeout, chore/update-deps"
+              exit 1
+              ;;
+          esac

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ All three must pass.
 
 ## Submitting Changes
 
-1. Fork the repo and create a branch off `main`
+1. Fork the repo and create a branch off `main` using `bugfix/`, `feature/`, or `chore/` as the prefix
 2. Make your changes following TDD and the code standards below
 3. Run `bun run typecheck && bun test && bun run build` — all must pass
 4. Open a PR against `main`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![npm version](https://img.shields.io/npm/v/@hueyexe/opencode-ensemble.svg)](https://www.npmjs.com/package/@hueyexe/opencode-ensemble)
 [![npm downloads](https://img.shields.io/npm/dm/@hueyexe/opencode-ensemble.svg)](https://www.npmjs.com/package/@hueyexe/opencode-ensemble)
-[![tests](https://img.shields.io/badge/tests-558%20passing-brightgreen.svg)]()
+[![tests](https://img.shields.io/badge/tests-560%20passing-brightgreen.svg)]()
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue.svg)]()
 [![OpenCode SDK](https://img.shields.io/badge/deps-OpenCode%20SDK%20only-blue.svg)]()
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
@@ -412,7 +412,7 @@ Same coordination model (shared tasks, peer messaging, lead coordination) with s
 ```bash
 bun install
 bun run typecheck
-bun test             # 558 tests
+bun test             # 560 tests
 bun run build
 ```
 

--- a/test/branch-policy.test.ts
+++ b/test/branch-policy.test.ts
@@ -1,0 +1,31 @@
+import { existsSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+const root = join(import.meta.dir, "..")
+const workflowPath = join(root, ".github", "workflows", "branch-name.yml")
+const contributingPath = join(root, "CONTRIBUTING.md")
+
+describe("branch naming policy", () => {
+  test("documents the allowed branch prefixes", () => {
+    const contributing = readFileSync(contributingPath, "utf8")
+
+    expect(contributing).toContain("bugfix/")
+    expect(contributing).toContain("feature/")
+    expect(contributing).toContain("chore/")
+  })
+
+  test("checks pull request branches for allowed prefixes", () => {
+    expect(existsSync(workflowPath)).toBe(true)
+
+    const workflow = readFileSync(workflowPath, "utf8")
+    expect(workflow).toContain("pull_request")
+    expect(workflow).toContain("github.head_ref")
+    expect(workflow).toContain("HEAD_REF: ${{ github.head_ref }}")
+    expect(workflow).toContain('case "$HEAD_REF" in')
+    expect(workflow).not.toContain('case "${{ github.head_ref }}" in')
+    expect(workflow).toContain("bugfix/*")
+    expect(workflow).toContain("feature/*")
+    expect(workflow).toContain("chore/*")
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a PR check for `bugfix/`, `feature/`, and `chore/` branch prefixes.
- Documents the branch naming convention in CONTRIBUTING.
- Adds coverage for the workflow and docs.

## Test Plan
- bun test test/branch-policy.test.ts
- bun run typecheck && bun test && bun run build

Also configured repository ruleset `Branch prefix naming` to block creating same-repo branches outside the allowed prefixes.