### PR TITLE
Fix Desktop runtime compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
         with:
           bun-version: "1.3"
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
       - run: bun install --frozen-lockfile
 
       - name: Typecheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,8 @@ Key SDK primitives:
 
 ### Storage
 
-SQLite via bun:sqlite (zero dependencies). Four tables:
+SQLite via the internal database adapter (zero external dependencies): `bun:sqlite`
+when running on Bun, `node:sqlite` when running on Node/Electron. Four tables:
 - team — team config (name, lead session, status, delegate mode)
 - team_member — member registry (name, session ID, agent, status)
 - team_task — shared task board (content, status, priority, assignee, deps)
@@ -130,7 +131,7 @@ Three hooks wired in index.ts:
 
 ## Settled Decisions (Do Not Re-Debate)
 
-1. SQLite via bun:sqlite — not file JSON, not in-memory-only
+1. SQLite via the internal database adapter — not file JSON, not in-memory-only, not external native packages
 2. promptAsync for message delivery — not session injection, not polling
 3. 14 separate tools — not a unified action tool, no exceptions
 4. Fire-and-forget spawn — not blocking, not tmux
@@ -316,7 +317,7 @@ Teammates do not need to know how agent teams work internally.
 
 - TypeScript strict mode
 - Biome linter with `noExplicitAny: error` — no `any` types, no `as any` casts
-- Zero external deps beyond @opencode-ai/sdk, @opencode-ai/plugin, bun:sqlite
+- Zero external deps beyond @opencode-ai/sdk and @opencode-ai/plugin; SQLite access stays behind src/db.ts
 - Every exported function has a JSDoc comment
 - const over let, early returns over else
 - snake_case for SQL columns, camelCase for TypeScript
@@ -352,7 +353,7 @@ Default to using Bun instead of Node.js.
 - Use `bun run <script>` instead of `npm run <script>` or `yarn run <script>` or `pnpm run <script>`
 - Use `bunx <package> <command>` instead of `npx <package> <command>`
 - Bun automatically loads .env, so don't use dotenv.
-- `bun:sqlite` for SQLite. Don't use `better-sqlite3`.
+- Use the database adapter in `src/db.ts` for SQLite. It selects `bun:sqlite` on Bun and `node:sqlite` on Node/Electron. Don't use `better-sqlite3`, and don't import runtime-specific SQLite modules outside `src/db.ts`.
 - Prefer `Bun.file` over `node:fs`'s readFile/writeFile
 
 ## Publishing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ All PRs require at least one approval from a code owner before merging. Direct p
 - `const` over `let`, early returns over `else`
 - `snake_case` for SQL columns, `camelCase` for TypeScript
 - Functional array methods over `for` loops
-- Zero external dependencies beyond `@opencode-ai/sdk`, `@opencode-ai/plugin`, and `bun:sqlite`
+- Zero external dependencies beyond `@opencode-ai/sdk` and `@opencode-ai/plugin`; SQLite goes through the internal adapter (`bun:sqlite` on Bun, `node:sqlite` on Node/Electron)
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![npm version](https://img.shields.io/npm/v/@hueyexe/opencode-ensemble.svg)](https://www.npmjs.com/package/@hueyexe/opencode-ensemble)
 [![npm downloads](https://img.shields.io/npm/dm/@hueyexe/opencode-ensemble.svg)](https://www.npmjs.com/package/@hueyexe/opencode-ensemble)
-[![tests](https://img.shields.io/badge/tests-561%20passing-brightgreen.svg)]()
+[![tests](https://img.shields.io/badge/tests-568%20passing-brightgreen.svg)]()
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue.svg)]()
 [![OpenCode SDK](https://img.shields.io/badge/deps-OpenCode%20SDK%20only-blue.svg)]()
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
@@ -19,7 +19,7 @@ Plugin built on the public OpenCode SDK. No internal dependencies.
 
 ```json
 {
-  "plugin": ["@hueyexe/opencode-ensemble@0.14.1"]
+  "plugin": ["@hueyexe/opencode-ensemble@0.14.2"]
 }
 ```
 
@@ -175,7 +175,7 @@ Add to your OpenCode config with a pinned version. Project-level or global.
 
 ```json
 {
-  "plugin": ["@hueyexe/opencode-ensemble@0.14.1"]
+  "plugin": ["@hueyexe/opencode-ensemble@0.14.2"]
 }
 ```
 
@@ -183,7 +183,7 @@ Add to your OpenCode config with a pinned version. Project-level or global.
 
 ```json
 {
-  "plugin": ["@hueyexe/opencode-ensemble@0.14.1"]
+  "plugin": ["@hueyexe/opencode-ensemble@0.14.2"]
 }
 ```
 
@@ -280,7 +280,7 @@ Teammate messages arrive in the lead's session as `[Team message from alice]: ..
 
 ## Architecture
 
-- **SQLite** (`bun:sqlite`, WAL mode) for teams, members, tasks, and messages
+- **SQLite** (WAL mode) for teams, members, tasks, and messages. Uses `bun:sqlite` in Bun and `node:sqlite` in Node/Electron through the internal database adapter.
 - **promptAsync** for message delivery: injects a message and starts the prompt loop in one call
 - **Git worktree isolation**: each teammate gets their own worktree by default, so multiple agents can edit files without conflicts. Opt out with `worktree: false` for read-only agents.
 - **System prompt injection**: the lead's system prompt includes team state (member statuses, task counts) on every LLM call. Teammates get a short role reminder.
@@ -447,7 +447,7 @@ Same coordination model (shared tasks, peer messaging, lead coordination) with s
 ```bash
 bun install
 bun run typecheck
-bun test             # 561 tests
+bun test             # 568 tests
 bun run build
 ```
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,13 @@ Set to `0` to disable. The dashboard starts automatically when OpenCode loads th
 
 Two steps: add the plugin, then allowlist worktree paths.
 
+### Runtime requirements
+
+The plugin uses SQLite via the host's runtime adapter:
+
+- **Bun**: any version with `bun:sqlite` (Bun ≥ 1.0).
+- **Node / Electron** (e.g. opencode Desktop): **Node ≥ 24** for stable `node:sqlite`. Older Node (20.x) lacks the module entirely; Node 22.5–23 has it behind `--experimental-sqlite`. If you load the plugin under an older Node and see `Cannot find module 'node:sqlite'` at startup, your runtime is too old.
+
 ### 1. Add the plugin
 
 Add to your OpenCode config with a pinned version. Project-level or global.

--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "opencode-ensemble",
       "dependencies": {
-        "@opencode-ai/plugin": "^1.14.45",
-        "@opencode-ai/sdk": "^1.14.45",
+        "@opencode-ai/plugin": "^1.15.1",
+        "@opencode-ai/sdk": "^1.15.1",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.9",
@@ -48,9 +48,9 @@
 
     "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ=="],
 
-    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.14.45", "", { "dependencies": { "@opencode-ai/sdk": "1.14.45", "effect": "4.0.0-beta.59", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.2.6", "@opentui/keymap": ">=0.2.6", "@opentui/solid": ">=0.2.6" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-EDUJ2pemKqx9wyFb5eYpGcxsTxe/mW0+N+BYJJJPFcTaMv8E8wWP2Kf+vmN15HeASMcZKeTwMsLVmsZfSpv2Yw=="],
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.15.1", "", { "dependencies": { "@opencode-ai/sdk": "1.15.1", "effect": "4.0.0-beta.65", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.2.11", "@opentui/keymap": ">=0.2.11", "@opentui/solid": ">=0.2.11" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-A9blDvAdr1PpTCjY2/lCD5cfd+VIe0GNhmnLF4O298kp+TA+JLFhNrJDoCXYKzNngCacI+pRRxAWA2L299BR6g=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.14.45", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-KKr+Pmb7ZD8BTflFbbeKBCb3kg7k3+bgikbn+n6A6v0djgnaQ9Qvv2eTDByI44jvU1c+bFiHWP4yxidx5WT2dw=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.15.1", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-IHxGuizTR2x40GtB49o0swFTc1N4AZIdeYzJ5D8gVAJzfISKyOYn5o5YxDprYJ7z4oWxBXNELIDpYioGVDUkNw=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -64,7 +64,7 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
-    "effect": ["effect@4.0.0-beta.59", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-xyUDLeHSe8d6lWGOvR6Fgn2HL6gYeTZ/S4Jzk9uc4ZUxMPPsNZlNXrvk0C7/utQFzeX7uAWcVnG2BjbA0SRoAA=="],
+    "effect": ["effect@4.0.0-beta.65", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-QYKvQPAj3CmtsvWkHQww15wX4KG2gNsszDWEcOO5sZCMknp66u6Si/Opmt3wwWCwsyvRmDAdIg+JIz5qzbbFIw=="],
 
     "fast-check": ["fast-check@4.7.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ=="],
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
     "build": "bun build src/index.ts --outdir dist --target node",
     "prepublishOnly": "bun run typecheck && bun test && bun run build"
   },
+  "engines": {
+    "node": ">=24",
+    "bun": ">=1.0"
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.4.9",
     "@types/bun": "latest"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hueyexe/opencode-ensemble",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Agent teams for OpenCode — parallel agents with peer-to-peer communication, shared tasks, and coordinated execution",
   "module": "src/index.ts",
   "main": "dist/index.js",
@@ -30,7 +30,7 @@
     "lint": "bunx biome lint src/",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
-    "build": "bun build src/index.ts --outdir dist --target bun",
+    "build": "bun build src/index.ts --outdir dist --target node",
     "prepublishOnly": "bun run typecheck && bun test && bun run build"
   },
   "devDependencies": {
@@ -41,7 +41,7 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@opencode-ai/plugin": "^1.14.45",
-    "@opencode-ai/sdk": "^1.14.45"
+    "@opencode-ai/plugin": "^1.15.1",
+    "@opencode-ai/sdk": "^1.15.1"
   }
 }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,4 +1,6 @@
-import type { Database } from "bun:sqlite"
+import { createServer } from "node:http"
+import type { IncomingMessage, Server, ServerResponse } from "node:http"
+import type { Database } from "./db"
 import { DASHBOARD_HEAD } from "./dashboard-html"
 import { DASHBOARD_JS_PART1 } from "./dashboard-js-part1"
 import { DASHBOARD_JS_PART2 } from "./dashboard-js-part2"
@@ -49,13 +51,6 @@ interface MessageRow {
   delivered: number
   read: number
   time_created: number
-}
-
-function jsonResponse(data: unknown, status = 200): Response {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
-  })
 }
 
 function parseDependsOn(value: string | null): string[] {
@@ -122,60 +117,92 @@ function buildState(db: Database): { teams: unknown[] } {
   }
 }
 
+/** Dashboard server handle returned by startDashboard. */
+export interface DashboardServer {
+  stop(force?: boolean): void
+}
+
+function sendJson(res: ServerResponse, data: unknown): void {
+  res.writeHead(200, {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+  })
+  res.end(JSON.stringify(data))
+}
+
+function handleDashboardRequest(db: Database, port: number, req: IncomingMessage, res: ServerResponse): void {
+  const url = new URL(req.url ?? "/", `http://${req.headers.host ?? `localhost:${port}`}`)
+
+  if (url.pathname === "/api/health") {
+    sendJson(res, { ensemble: true, pid: process.pid })
+    return
+  }
+
+  if (url.pathname === "/api/state") {
+    sendJson(res, buildState(db))
+    return
+  }
+
+  if (url.pathname === "/") {
+    res.writeHead(200, { "Content-Type": "text/html" })
+    res.end(DASHBOARD_HTML)
+    return
+  }
+
+  res.writeHead(404, { "Content-Type": "text/plain" })
+  res.end("Not Found")
+}
+
+function toDashboardServer(server: Server): DashboardServer {
+  return {
+    stop() {
+      server.close()
+    },
+  }
+}
+
 /**
  * Start the dashboard HTTP server.
  * Serves a JSON API for team state and the dashboard HTML.
  * Singleton: if the port is already in use by another ensemble instance, skips silently.
  * Returns the server instance, or null if skipped.
  */
-export async function startDashboard(db: Database, port: number): Promise<ReturnType<typeof Bun.serve> | null> {
-  try {
-    const server = Bun.serve({
-      port,
-      fetch(req) {
-        const url = new URL(req.url)
+export async function startDashboard(db: Database, port: number): Promise<DashboardServer | null> {
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => handleDashboardRequest(db, port, req, res))
 
-        if (url.pathname === "/api/health") {
-          return jsonResponse({ ensemble: true, pid: process.pid })
-        }
-
-        if (url.pathname === "/api/state") {
-          return jsonResponse(buildState(db))
-        }
-
-        if (url.pathname === "/") {
-          return new Response(DASHBOARD_HTML, {
-            headers: { "Content-Type": "text/html" },
-          })
-        }
-
-        return new Response("Not Found", { status: 404 })
-      },
-    })
-    log(`dashboard:started port=${port} url=http://localhost:${port}`)
-    return server
-  } catch (err) {
-    if (err && typeof err === "object" && "code" in err && err.code === "EADDRINUSE") {
-      try {
-        const res = await fetch(`http://localhost:${port}/api/health`)
-        const data = await res.json() as { ensemble?: boolean; pid?: number }
-        if (data.ensemble && data.pid) {
-          // Check if the other process is still alive
-          let alive = false
-          try { process.kill(data.pid, 0); alive = true } catch { /* process is dead */ }
-          if (alive && data.pid !== process.pid) {
-            log(`dashboard:already-running port=${port} pid=${data.pid}`)
-            return null
+    server.once("error", async (err: NodeJS.ErrnoException) => {
+      if (err.code === "EADDRINUSE") {
+        try {
+          const res = await fetch(`http://localhost:${port}/api/health`)
+          const data = await res.json() as { ensemble?: boolean; pid?: number }
+          if (data.ensemble && data.pid) {
+            // Check if the other process is still alive
+            let alive = false
+            try { process.kill(data.pid, 0); alive = true } catch { /* process is dead */ }
+            if (alive && data.pid !== process.pid) {
+              log(`dashboard:already-running port=${port} pid=${data.pid}`)
+              resolve(null)
+              return
+            }
+            // Stale server from a dead process — warn the user
+            log(`dashboard:stale-server port=${port} stale-pid=${data.pid} — run: kill -9 ${data.pid} || lsof -ti:${port} | xargs kill -9`)
+            resolve(null)
+            return
           }
-          // Stale server from a dead process — warn the user
-          log(`dashboard:stale-server port=${port} stale-pid=${data.pid} — run: kill -9 ${data.pid} || lsof -ti:${port} | xargs kill -9`)
-          return null
-        }
-      } catch { /* health check failed — port held by something else */ }
-      log(`dashboard:port-in-use port=${port} (not an ensemble instance)`)
-      return null
-    }
-    log(`dashboard:failed err=${err instanceof Error ? err.message : String(err)}`)
-    return null
-  }
+        } catch { /* health check failed — port held by something else */ }
+        log(`dashboard:port-in-use port=${port} (not an ensemble instance)`)
+        resolve(null)
+        return
+      }
+
+      log(`dashboard:failed err=${err.message}`)
+      resolve(null)
+    })
+
+    server.listen(port, () => {
+      log(`dashboard:started port=${port} url=http://localhost:${port}`)
+      resolve(toDashboardServer(server))
+    })
+  })
 }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -155,8 +155,16 @@ function handleDashboardRequest(db: Database, port: number, req: IncomingMessage
 
 function toDashboardServer(server: Server): DashboardServer {
   return {
-    stop() {
+    stop(force?: boolean) {
       server.close()
+      // server.close() only stops accepting new connections — under Node's
+      // node:http, idle keep-alive sockets keep the listener busy until the
+      // keep-alive timeout. closeAllConnections() (Node ≥ 18.2) terminates
+      // them promptly, matching the behaviour Bun.serve().stop(true) had.
+      if (force) {
+        const closeAll = (server as unknown as { closeAllConnections?: () => void }).closeAllConnections
+        if (typeof closeAll === "function") closeAll.call(server)
+      }
     },
   }
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,8 +1,92 @@
-import { Database } from "bun:sqlite"
+import { createRequire } from "node:module"
 import path from "node:path"
 import { applyMigrations } from "./schema"
 
+interface SqliteStatement {
+  get(...params: unknown[]): unknown
+  all(...params: unknown[]): unknown[]
+  run(...params: unknown[]): unknown
+}
+
+interface SqliteRunResult {
+  changes: number
+}
+
+/** Minimal synchronous SQLite database interface used by Ensemble. */
+export interface Database {
+  exec(sql: string): void
+  query(sql: string): SqliteStatement
+  run(sql: string, ...params: unknown[]): SqliteRunResult
+  transaction<TArgs extends unknown[], TResult>(fn: (...args: TArgs) => TResult): (...args: TArgs) => TResult
+  close(): void
+}
+
+interface BunSqliteModule {
+  Database: new (filename: string) => Database
+}
+
+interface NodeSqliteDatabase {
+  exec(sql: string): void
+  prepare(sql: string): SqliteStatement
+  close(): void
+}
+
+interface NodeSqliteModule {
+  DatabaseSync: new (filename: string) => NodeSqliteDatabase
+}
+
+const requireRuntimeModule = createRequire(import.meta.url)
+
 let instance: Database | undefined
+
+class NodeSqliteAdapter implements Database {
+  private readonly db: NodeSqliteDatabase
+
+  constructor(filename: string) {
+    const sqlite = requireRuntimeModule("node:sqlite") as NodeSqliteModule
+    this.db = new sqlite.DatabaseSync(filename)
+  }
+
+  exec(sql: string): void {
+    this.db.exec(sql)
+  }
+
+  query(sql: string): SqliteStatement {
+    return this.db.prepare(sql)
+  }
+
+  run(sql: string, ...params: unknown[]): SqliteRunResult {
+    const bindings = params.length === 1 && Array.isArray(params[0]) ? params[0] : params
+    return this.db.prepare(sql).run(...bindings) as SqliteRunResult
+  }
+
+  transaction<TArgs extends unknown[], TResult>(fn: (...args: TArgs) => TResult): (...args: TArgs) => TResult {
+    return (...args: TArgs): TResult => {
+      this.exec("BEGIN")
+      try {
+        const result = fn(...args)
+        this.exec("COMMIT")
+        return result
+      } catch (err) {
+        this.exec("ROLLBACK")
+        throw err
+      }
+    }
+  }
+
+  close(): void {
+    this.db.close()
+  }
+}
+
+function openDatabase(filename: string): Database {
+  if (typeof process.versions.bun === "string") {
+    const sqlite = requireRuntimeModule(["bun", "sqlite"].join(":")) as BunSqliteModule
+    return new sqlite.Database(filename)
+  }
+
+  return new NodeSqliteAdapter(filename)
+}
 
 /**
  * Resolve the path for the ensemble SQLite database.
@@ -19,7 +103,7 @@ export function getDbPath(env: Record<string, string | undefined> = process.env)
  * Applies all pending migrations and enables WAL mode.
  */
 export function createDb(path: string): Database {
-  const db = new Database(path)
+  const db = openDatabase(path)
   db.exec("PRAGMA journal_mode=WAL")
   db.exec("PRAGMA foreign_keys=ON")
   applyMigrations(db)

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -95,22 +95,36 @@ export function handleSessionCreatedEvent(
  * Check whether a tool call should be blocked for sub-agent isolation.
  * Throws if the tool is a team tool and the session is a descendant of a team member.
  * OQ-11: confirmed — throwing inside tool.execute.before fails the tool call gracefully (verified in live testing).
+ *
+ * The optional `db` parameter enables a SQLite fallback so the check works
+ * across multi-Plugin-instance scenarios where the in-memory registry may
+ * not have the parent teammate's session. SQLite is the canonical source.
  */
 export function checkToolIsolation(
   registry: MemberRegistry,
   tracker: DescendantTracker,
   toolName: string,
   sessionId: string,
+  db?: Database,
 ): void {
   if (!toolName.startsWith(TEAM_TOOL_PREFIX)) return
 
-  // If the session is a registered team member or lead, allow it
-  if (registry.isTeamSession(sessionId)) return
+  // Collect every session ID that is a teammate, from the registry first
+  // (fast path) and SQLite second (covers multi-instance / cross-plugin state).
+  const teammateSessionIds = new Set(registry.allSessionIds())
+  if (db) {
+    const dbRows = db.query(
+      `SELECT tm.session_id FROM team_member tm
+       JOIN team t ON tm.team_id = t.id
+       WHERE t.status = 'active' AND tm.status NOT IN ('shutdown', 'error')`
+    ).all() as Array<{ session_id: string }>
+    for (const row of dbRows) teammateSessionIds.add(row.session_id)
+  }
 
-  // Check if this session is a descendant of any team member
-  const allTeamSessions = registry.allSessionIds()
+  // If the session is itself a teammate, allow the call
+  if (teammateSessionIds.has(sessionId)) return
 
-  if (allTeamSessions.size > 0 && tracker.isDescendantOf(sessionId, allTeamSessions)) {
+  if (teammateSessionIds.size > 0 && tracker.isDescendantOf(sessionId, teammateSessionIds)) {
     throw new Error("Team tools are not available to sub-agents. Report findings to your parent teammate via your normal output.")
   }
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -108,7 +108,10 @@ export function handleSessionCreatedEvent(
  *   4. If the caller is a descendant of any teammate, block.
  *
  * The fast-path skips the SQL query entirely when the registry already
- * has the caller — every tool call from a registered teammate stays cheap.
+ * has the caller. Lead sessions are NOT in the MemberRegistry by design
+ * (only teammates are), so a lead's team_* call always misses the
+ * fast-path and does the SQLite enumeration. That's acceptable — the
+ * scan is bounded by total active members and runs once per tool call.
  */
 export function checkToolIsolation(
   registry: MemberRegistry,

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,4 +1,4 @@
-import type { Database } from "bun:sqlite"
+import type { Database } from "./db"
 import type { MemberRegistry, DescendantTracker } from "./state"
 
 const TEAM_TOOL_PREFIX = "team_"

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,5 +1,6 @@
 import type { Database } from "./db"
 import type { MemberRegistry, DescendantTracker } from "./state"
+import { sendMessage } from "./messaging"
 
 const TEAM_TOOL_PREFIX = "team_"
 
@@ -126,4 +127,37 @@ export function shouldNudgeIdleMember(db: Database, teamId: string, memberName: 
   const msg = db.query("SELECT id FROM team_message WHERE team_id = ? AND from_name = ? AND (to_name = 'lead' OR to_name IS NULL) LIMIT 1")
     .get(teamId, memberName) as { id: string } | null
   return !msg
+}
+
+/** Shape of an error attached to a session.error event. Subset of the SDK's union. */
+export interface SessionErrorPayload {
+  name?: string
+  data?: { message?: string }
+}
+
+/**
+ * Handle a session.error event. Surfaces tool/model failures from a teammate
+ * as a system message to the lead, so otherwise-silent failures are visible.
+ *
+ * Ignored when:
+ * - sessionID is undefined
+ * - the session is not a registered teammate (leads are not in the registry)
+ */
+export function handleSessionErrorEvent(
+  db: Database,
+  registry: MemberRegistry,
+  sessionId: string | undefined,
+  error: SessionErrorPayload | undefined,
+): void {
+  if (!sessionId) return
+  const entry = registry.getBySession(sessionId)
+  if (!entry) return
+
+  const errMsg = error?.data?.message ?? error?.name ?? "unknown error"
+  sendMessage(db, {
+    teamId: entry.teamId,
+    from: "system",
+    to: "lead",
+    content: `Teammate "${entry.memberName}" had a session error: ${errMsg}. Check their session for details. They may be stuck and need investigation or shutdown.`,
+  })
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,6 +1,7 @@
 import type { Database } from "./db"
 import type { MemberRegistry, DescendantTracker } from "./state"
 import { sendMessage } from "./messaging"
+import { findTeamBySession } from "./types"
 
 const TEAM_TOOL_PREFIX = "team_"
 
@@ -99,6 +100,15 @@ export function handleSessionCreatedEvent(
  * The optional `db` parameter enables a SQLite fallback so the check works
  * across multi-Plugin-instance scenarios where the in-memory registry may
  * not have the parent teammate's session. SQLite is the canonical source.
+ *
+ * Order:
+ *   1. Registry fast-path: if the caller is itself a registered teammate, allow.
+ *   2. Otherwise enumerate active teammate session IDs from registry + SQLite.
+ *   3. If the caller is among them, allow.
+ *   4. If the caller is a descendant of any teammate, block.
+ *
+ * The fast-path skips the SQL query entirely when the registry already
+ * has the caller — every tool call from a registered teammate stays cheap.
  */
 export function checkToolIsolation(
   registry: MemberRegistry,
@@ -108,6 +118,9 @@ export function checkToolIsolation(
   db?: Database,
 ): void {
   if (!toolName.startsWith(TEAM_TOOL_PREFIX)) return
+
+  // Fast path: registry hit on the caller — skip SQL altogether.
+  if (registry.isTeamSession(sessionId)) return
 
   // Collect every session ID that is a teammate, from the registry first
   // (fast path) and SQLite second (covers multi-instance / cross-plugin state).
@@ -121,7 +134,7 @@ export function checkToolIsolation(
     for (const row of dbRows) teammateSessionIds.add(row.session_id)
   }
 
-  // If the session is itself a teammate, allow the call
+  // The caller may be a teammate registered in another Plugin instance — allow.
   if (teammateSessionIds.has(sessionId)) return
 
   if (teammateSessionIds.size > 0 && tracker.isDescendantOf(sessionId, teammateSessionIds)) {
@@ -164,14 +177,17 @@ export function handleSessionErrorEvent(
   error: SessionErrorPayload | undefined,
 ): void {
   if (!sessionId) return
-  const entry = registry.getBySession(sessionId)
-  if (!entry) return
+  // Use findTeamBySession so the SQLite fallback fires when this Plugin
+  // instance's in-memory registry doesn't have the teammate (multi-instance
+  // scenario — see findTeamBySession in src/types.ts).
+  const teamInfo = findTeamBySession(db, registry, sessionId)
+  if (!teamInfo || teamInfo.role !== "member" || !teamInfo.memberName) return
 
   const errMsg = error?.data?.message ?? error?.name ?? "unknown error"
   sendMessage(db, {
-    teamId: entry.teamId,
+    teamId: teamInfo.teamId,
     from: "system",
     to: "lead",
-    content: `Teammate "${entry.memberName}" had a session error: ${errMsg}. Check their session for details. They may be stuck and need investigation or shutdown.`,
+    content: `Teammate "${teamInfo.memberName}" had a session error: ${errMsg}. Check their session for details. They may be stuck and need investigation or shutdown.`,
   })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,10 @@ import path from "node:path"
 import { mkdirSync } from "node:fs"
 import { createDb, getDbPath } from "./db"
 import { wrapThrowingClient } from "./client"
-import { recoverStaleMembers, recoverUndeliveredMessages, recoverOrphanedWorktrees, recoverOrphanedBranches } from "./recovery"
+import { recoverStaleMembers, recoverUndeliveredMessages, recoverOrphanedWorktrees, recoverOrphanedBranches, rehydrateRegistry } from "./recovery"
 import { MemberRegistry, DescendantTracker, PendingPurgeApprovals } from "./state"
 import { isWorktreeInstance } from "./util"
-import { handleSessionStatusEvent, handleSessionCreatedEvent, checkToolIsolation, shouldNudgeIdleMember } from "./hooks"
+import { handleSessionStatusEvent, handleSessionCreatedEvent, checkToolIsolation, shouldNudgeIdleMember, handleSessionErrorEvent } from "./hooks"
 import { notifyTeamEvent, notifyWorkingProgress } from "./notify"
 import { sendMessage, hasReportedCompletion } from "./messaging"
 import { buildLeadSystemPrompt, buildTeammateSystemPrompt, buildTeamCompactionContext } from "./system-prompt"
@@ -80,13 +80,16 @@ const plugin: Plugin = async (input) => {
     const recovery = await recoverStaleMembers(db, client, input.directory)
     if (recovery.interrupted > 0) {
       log(`init:recovery:interrupted=${recovery.interrupted}`)
-      const members = db.query(
-        "SELECT tm.team_id, tm.name, tm.session_id FROM team_member tm JOIN team t ON tm.team_id = t.id WHERE t.status = 'active'"
-      ).all() as Array<{ team_id: string; name: string; session_id: string }>
-      for (const m of members) {
-        registry.register(m.team_id, m.name, m.session_id)
-      }
     }
+
+    // Always rehydrate the in-memory registry from SQLite. The registry is
+    // in-memory only and is wiped on every plugin restart. Without this,
+    // teammates from a previous lifetime become invisible — every team_*
+    // tool call from them throws "This session is not in a team." This is
+    // the bug that surfaced on Desktop, where the Electron sidecar restarts
+    // far more often than the CLI.
+    const rehydrated = rehydrateRegistry(db, registry)
+    if (rehydrated > 0) log(`init:registry:rehydrated members=${rehydrated}`)
 
     recoverUndeliveredMessages(db, client, registry).catch((err) => {
       log(`init:recover-messages:failed err=${err instanceof Error ? err.message : String(err)}`)
@@ -283,6 +286,15 @@ const plugin: Plugin = async (input) => {
         if (info.parentID) {
           handleSessionCreatedEvent(tracker, info.id, info.parentID)
         }
+      }
+
+      // Surface teammate session errors as system messages to the lead.
+      // Without this, errors during a teammate's prompt loop (auth failure,
+      // tool failure, model error, etc.) are invisible to the lead — the
+      // teammate just appears stuck.
+      if (event.type === "session.error") {
+        const props = event.properties as { sessionID?: string; error?: { name?: string; data?: { message?: string } } }
+        handleSessionErrorEvent(db, registry, props.sessionID, props.error)
       }
 
       // Track per-step output tokens for stall detection

--- a/src/index.ts
+++ b/src/index.ts
@@ -310,7 +310,7 @@ const plugin: Plugin = async (input) => {
 
     // Sub-agent isolation + rate limiting hook
     "tool.execute.before": async (input, _output) => {
-      checkToolIsolation(registry, tracker, input.tool, input.sessionID)
+      checkToolIsolation(registry, tracker, input.tool, input.sessionID, db)
       // Rate limit team tools that trigger LLM inference
       if (input.tool.startsWith("team_")) {
         if (!rateLimiter.tryConsume()) {

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -1,4 +1,4 @@
-import type { Database } from "bun:sqlite"
+import type { Database } from "./db"
 import { generateId } from "./util"
 
 const MAX_CONTENT_BYTES = 10 * 1024 // 10KB

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -1,4 +1,4 @@
-import type { Database } from "bun:sqlite"
+import type { Database } from "./db"
 import type { PluginClient } from "./types"
 
 type TeamEventType = "spawn" | "message" | "completed" | "error" | "shutdown"

--- a/src/process.ts
+++ b/src/process.ts
@@ -1,0 +1,55 @@
+import { Buffer } from "node:buffer"
+import { spawn } from "node:child_process"
+import type { Readable } from "node:stream"
+
+export interface CommandResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+export interface CommandOptions {
+  cwd?: string
+}
+
+function collect(stream: Readable | null, chunks: Buffer[]): void {
+  stream?.on("data", (chunk: Buffer | string) => {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  })
+}
+
+/** Run a subprocess with Node-compatible APIs and capture stdout/stderr. */
+export function runCommand(args: string[], options: CommandOptions = {}): Promise<CommandResult> {
+  const [command, ...commandArgs] = args
+  if (!command) return Promise.resolve({ exitCode: 1, stdout: "", stderr: "No command provided" })
+
+  return new Promise((resolve) => {
+    const stdout: Buffer[] = []
+    const stderr: Buffer[] = []
+    let settled = false
+    const finish = (result: CommandResult) => {
+      if (settled) return
+      settled = true
+      resolve(result)
+    }
+
+    const child = spawn(command, commandArgs, {
+      cwd: options.cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+
+    collect(child.stdout, stdout)
+    collect(child.stderr, stderr)
+
+    child.on("error", (error) => {
+      finish({ exitCode: 1, stdout: Buffer.concat(stdout).toString("utf8"), stderr: error.message })
+    })
+    child.on("close", (code) => {
+      finish({
+        exitCode: code ?? 1,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+      })
+    })
+  })
+}

--- a/src/recovery.ts
+++ b/src/recovery.ts
@@ -1,9 +1,10 @@
-import type { Database } from "bun:sqlite"
+import type { Database } from "./db"
 import type { PluginClient } from "./types"
 import type { MemberRegistry } from "./state"
 import { getUndeliveredMessages, markDelivered, hasReportedCompletion } from "./messaging"
 import { preserveBranch, preservedBranchName } from "./tools/merge-helper"
 import { log } from "./log"
+import { runCommand } from "./process"
 
 /**
  * Scan for team members stuck in 'busy' status (stale from a crash)
@@ -168,12 +169,9 @@ export async function recoverOrphanedBranches(db: Database, cwd: string): Promis
   const archivedNames = new Set(archivedTeams.map(t => t.name))
 
   // List all local branches matching ensemble/preserved/*
-  const proc = Bun.spawn(["git", "branch", "--list", "ensemble/preserved/*"], { cwd, stdout: "pipe", stderr: "pipe" })
-  const stdoutPromise = new Response(proc.stdout).text()
-  await proc.exited
-  const stdout = await stdoutPromise
+  const result = await runCommand(["git", "branch", "--list", "ensemble/preserved/*"], { cwd })
 
-  const branches = stdout.split("\n").map(b => b.trim().replace(/^\* /, "")).filter(Boolean)
+  const branches = result.stdout.split("\n").map(b => b.trim().replace(/^\* /, "")).filter(Boolean)
 
   for (const branch of branches) {
     // Parse team name from branch: ensemble/preserved/{teamName}/{memberName}
@@ -183,9 +181,8 @@ export async function recoverOrphanedBranches(db: Database, cwd: string): Promis
     if (!teamName || !archivedNames.has(teamName)) continue
 
     try {
-      const del = Bun.spawn(["git", "branch", "-D", branch], { cwd, stdout: "pipe", stderr: "pipe" })
-      const exitCode = await del.exited
-      if (exitCode === 0) {
+      const deleteResult = await runCommand(["git", "branch", "-D", branch], { cwd })
+      if (deleteResult.exitCode === 0) {
         removed++
         log(`recovery:branch:deleted branch=${branch}`)
       }

--- a/src/recovery.ts
+++ b/src/recovery.ts
@@ -147,6 +147,30 @@ export async function recoverUndeliveredMessages(
 }
 
 /**
+ * Repopulate the in-memory MemberRegistry from SQLite for all active members.
+ * MUST be called on every plugin init — the registry is in-memory only,
+ * and without rehydration, every team_* tool call from an existing
+ * teammate fails with "This session is not in a team." after a plugin restart.
+ *
+ * Skips members in terminal states (shutdown, error) — they should not
+ * receive future messages.
+ *
+ * Returns the number of members rehydrated.
+ */
+export function rehydrateRegistry(db: Database, registry: MemberRegistry): number {
+  const members = db.query(
+    `SELECT tm.team_id, tm.name, tm.session_id
+     FROM team_member tm
+     JOIN team t ON tm.team_id = t.id
+     WHERE t.status = 'active' AND tm.status NOT IN ('shutdown', 'error')`
+  ).all() as Array<{ team_id: string; name: string; session_id: string }>
+  for (const m of members) {
+    registry.register(m.team_id, m.name, m.session_id)
+  }
+  return members.length
+}
+
+/**
  * Clean up orphaned ensemble/preserved/* branches that belong to archived teams
  * with no active members. Scoped carefully to avoid interfering with other
  * running OpenCode sessions that may have active teams.

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,4 +1,4 @@
-import type { Database } from "bun:sqlite"
+import type { Database } from "./db"
 
 /** Migration SQL statements, applied in order. Version = index + 1. */
 export const MIGRATIONS: string[] = [

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -1,4 +1,4 @@
-import type { Database } from "bun:sqlite"
+import type { Database } from "./db"
 import { markDelivered } from "./messaging"
 import { parseTaskResult, formatTaskResult } from "./result-parser"
 import type { EnsembleConfig } from "./config"

--- a/src/tools/merge-helper.ts
+++ b/src/tools/merge-helper.ts
@@ -1,4 +1,5 @@
 import { log } from "../log"
+import { runCommand } from "../process"
 
 /** Result of merging a single branch. */
 export interface MergeResult {
@@ -24,11 +25,9 @@ export type DeleteBranchFn = (branch: string, cwd: string) => Promise<boolean>
  * Returns true if the branch was successfully copied.
  */
 export async function preserveBranch(sourceBranch: string, targetBranch: string, cwd: string): Promise<boolean> {
-  const proc = Bun.spawn(["git", "branch", targetBranch, sourceBranch], { cwd, stdout: "pipe", stderr: "pipe" })
-  const exit = await proc.exited
-  if (exit !== 0) {
-    const stderr = await new Response(proc.stderr).text()
-    log(`merge-helper:preserve:failed src=${sourceBranch} target=${targetBranch} err=${stderr.trim()}`)
+  const result = await runCommand(["git", "branch", targetBranch, sourceBranch], { cwd })
+  if (result.exitCode !== 0) {
+    log(`merge-helper:preserve:failed src=${sourceBranch} target=${targetBranch} err=${result.stderr.trim()}`)
     return false
   }
   return true
@@ -38,9 +37,8 @@ export async function preserveBranch(sourceBranch: string, targetBranch: string,
  * Delete a git branch. Returns true if successful.
  */
 export async function deleteBranch(branch: string, cwd: string): Promise<boolean> {
-  const proc = Bun.spawn(["git", "branch", "-D", branch], { cwd, stdout: "pipe", stderr: "pipe" })
-  const exit = await proc.exited
-  if (exit !== 0) {
+  const result = await runCommand(["git", "branch", "-D", branch], { cwd })
+  if (result.exitCode !== 0) {
     log(`merge-helper:delete:failed branch=${branch}`)
     return false
   }
@@ -52,16 +50,13 @@ export async function deleteBranch(branch: string, cwd: string): Promise<boolean
  * Used by mergeBranch (single) and mergeMultipleBranches (batch).
  */
 export async function mergeBranchRaw(branch: string, cwd: string): Promise<MergeResult> {
-  const merge = Bun.spawn(["git", "merge", "--squash", branch], { cwd, stdout: "pipe", stderr: "pipe" })
-  const stderrPromise = new Response(merge.stderr).text()
-  const mergeExit = await merge.exited
+  const result = await runCommand(["git", "merge", "--squash", branch], { cwd })
 
-  if (mergeExit !== 0) {
-    const stderr = await stderrPromise
+  if (result.exitCode !== 0) {
+    const stderr = result.stderr.trim()
     log(`merge-helper:merge:conflict branch=${branch} err=${stderr.trim()}`)
-    const abort = Bun.spawn(["git", "merge", "--abort"], { cwd, stdout: "pipe", stderr: "pipe" })
-    await abort.exited
-    return { ok: false, error: stderr.trim() || `merge exited with code ${mergeExit}` }
+    await runCommand(["git", "merge", "--abort"], { cwd })
+    return { ok: false, error: stderr || `merge exited with code ${result.exitCode}` }
   }
 
   return { ok: true }
@@ -69,8 +64,7 @@ export async function mergeBranchRaw(branch: string, cwd: string): Promise<Merge
 
 /** Unstage all changes so merge results appear as unstaged. */
 export async function gitReset(cwd: string): Promise<void> {
-  const reset = Bun.spawn(["git", "reset", "HEAD"], { cwd, stdout: "pipe", stderr: "pipe" })
-  await reset.exited
+  await runCommand(["git", "reset", "HEAD"], { cwd })
 }
 
 /**
@@ -91,11 +85,9 @@ export async function mergeBranch(branch: string, cwd: string): Promise<MergeRes
  */
 export async function getOverlappingFiles(branch: string, cwd: string): Promise<string[]> {
   const run = async (args: string[]) => {
-    const proc = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" })
-    const out = await new Response(proc.stdout).text()
-    const exit = await proc.exited
-    if (exit !== 0) throw new Error(`git ${args.join(" ")} failed with exit code ${exit}`)
-    return out.split("\n").filter(Boolean)
+    const result = await runCommand(["git", ...args], { cwd })
+    if (result.exitCode !== 0) throw new Error(`git ${args.join(" ")} failed with exit code ${result.exitCode}`)
+    return result.stdout.split("\n").filter(Boolean)
   }
   const agentFiles = new Set(await run(["diff", "--name-only", "HEAD", branch]))
   const localChanged = await run(["diff", "--name-only", "HEAD"])

--- a/src/tools/merge-helper.ts
+++ b/src/tools/merge-helper.ts
@@ -54,7 +54,7 @@ export async function mergeBranchRaw(branch: string, cwd: string): Promise<Merge
 
   if (result.exitCode !== 0) {
     const stderr = result.stderr.trim()
-    log(`merge-helper:merge:conflict branch=${branch} err=${stderr.trim()}`)
+    log(`merge-helper:merge:conflict branch=${branch} err=${stderr}`)
     await runCommand(["git", "merge", "--abort"], { cwd })
     return { ok: false, error: stderr || `merge exited with code ${result.exitCode}` }
   }

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -1,5 +1,6 @@
 import type { ToolDeps } from "../types"
 import { findTeamBySession } from "../types"
+import { runCommand } from "../process"
 
 /** Function type for dirty worktree check — injectable for testing. */
 export type IsDirtyFn = (dir: string) => Promise<boolean>
@@ -10,11 +11,9 @@ export type CommitCountFn = (branch: string, cwd: string) => Promise<number>
 /** Count commits a branch has ahead of HEAD. Approximate — may include base divergence. Returns -1 if check fails. */
 export async function countBranchCommits(branch: string, cwd: string): Promise<number> {
   try {
-    const proc = Bun.spawn(["git", "rev-list", "--count", `HEAD..${branch}`], { cwd, stdout: "pipe", stderr: "pipe" })
-    const out = await new Response(proc.stdout).text()
-    const exit = await proc.exited
-    if (exit !== 0) return -1
-    const n = Number.parseInt(out.trim(), 10)
+    const result = await runCommand(["git", "rev-list", "--count", `HEAD..${branch}`], { cwd })
+    if (result.exitCode !== 0) return -1
+    const n = Number.parseInt(result.stdout.trim(), 10)
     return Number.isNaN(n) ? -1 : n
   } catch { return -1 }
 }
@@ -22,11 +21,9 @@ export async function countBranchCommits(branch: string, cwd: string): Promise<n
 /** Check if a worktree directory has uncommitted changes via git status. */
 export async function checkWorktreeDirty(dir: string): Promise<boolean> {
   try {
-    const proc = Bun.spawn(["git", "-C", dir, "status", "--porcelain"], { stdout: "pipe", stderr: "pipe" })
-    const output = await new Response(proc.stdout).text()
-    const exitCode = await proc.exited
-    if (exitCode !== 0) return false // git failed — assume clean
-    return output.trim().length > 0
+    const result = await runCommand(["git", "-C", dir, "status", "--porcelain"])
+    if (result.exitCode !== 0) return false // git failed — assume clean
+    return result.stdout.trim().length > 0
   } catch {
     return false // can't check — assume clean
   }

--- a/src/tools/team-cleanup.ts
+++ b/src/tools/team-cleanup.ts
@@ -5,6 +5,7 @@ import { spawnFailures } from "./team-spawn"
 import { mergeBranch, deleteBranch, preserveBranch, preservedBranchName, getOverlappingFiles } from "./merge-helper"
 import type { MergeBranchFn, DeleteBranchFn, PreserveBranchFn, OverlapCheckFn } from "./merge-helper"
 import { log } from "../log"
+import { runCommand } from "../process"
 
 type PurgeApprovalFn = (preview: string) => Promise<void>
 type ListBranchesFn = (teamName: string, cwd: string) => Promise<string[]>
@@ -36,12 +37,9 @@ interface PurgeMemberResource {
 
 async function listPreservedBranches(teamName: string, cwd: string): Promise<string[]> {
   try {
-    const proc = Bun.spawn(["git", "branch", "--list", `ensemble/preserved/${teamName}/*`, "--format", "%(refname:short)"], { cwd, stdout: "pipe", stderr: "pipe" })
-    const out = await new Response(proc.stdout).text()
-    const stderr = await new Response(proc.stderr).text()
-    const exit = await proc.exited
-    if (exit !== 0) throw new Error(stderr.trim() || `git branch exited with code ${exit}`)
-    return out.split("\n").map(branch => branch.trim()).filter(Boolean)
+    const result = await runCommand(["git", "branch", "--list", `ensemble/preserved/${teamName}/*`, "--format", "%(refname:short)"], { cwd })
+    if (result.exitCode !== 0) throw new Error(result.stderr.trim() || `git branch exited with code ${result.exitCode}`)
+    return result.stdout.split("\n").map(branch => branch.trim()).filter(Boolean)
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     if (message.includes("not a git repository")) return []
@@ -51,15 +49,12 @@ async function listPreservedBranches(teamName: string, cwd: string): Promise<str
 
 async function branchExists(branch: string, cwd: string): Promise<boolean> {
   try {
-    const proc = Bun.spawn(["git", "branch", "--list", branch, "--format", "%(refname:short)"], { cwd, stdout: "pipe", stderr: "pipe" })
-    const out = await new Response(proc.stdout).text()
-    const stderr = await new Response(proc.stderr).text()
-    const exit = await proc.exited
-    if (exit !== 0) {
-      if (stderr.includes("not a git repository")) return false
-      throw new Error(stderr.trim() || `git branch exited with code ${exit}`)
+    const result = await runCommand(["git", "branch", "--list", branch, "--format", "%(refname:short)"], { cwd })
+    if (result.exitCode !== 0) {
+      if (result.stderr.includes("not a git repository")) return false
+      throw new Error(result.stderr.trim() || `git branch exited with code ${result.exitCode}`)
     }
-    return out.split("\n").map(item => item.trim()).includes(branch)
+    return result.stdout.split("\n").map(item => item.trim()).includes(branch)
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     if (message.includes("not a git repository")) return false

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { Database } from "bun:sqlite"
+import type { Database } from "./db"
 import type { MemberRegistry, DescendantTracker, PendingPurgeApprovals } from "./state"
 import type { EnsembleConfig } from "./config"
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,7 +113,11 @@ export function findTeamBySession(
          AND tm.status NOT IN ('shutdown', 'error')`
     ).get(sessionId) as { team_id: string; member_name: string; team_name: string } | null
     if (memberRow) {
-      // Populate the cache so subsequent lookups skip the SQL query
+      // Populate the cache so subsequent lookups skip the SQL query.
+      // Safe without TTL: session IDs are server-generated UUIDs and are
+      // never reused across team_spawn invocations, so a session ID maps
+      // to at most one (teamId, memberName) for the life of the process.
+      // team_cleanup explicitly invalidates via registry.unregisterTeam.
       registry.register(memberRow.team_id, memberRow.member_name, sessionId)
       return { teamId: memberRow.team_id, teamName: memberRow.team_name, role: "member", memberName: memberRow.member_name }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,20 +76,50 @@ export interface PluginClient {
 /**
  * Look up which team a session belongs to (as lead or member).
  * Returns team info or undefined.
+ *
+ * Lookup order for member sessions:
+ *   1. Registry fast-path (in-memory cache)
+ *   2. SQLite fallback (canonical source)
+ *
+ * The SQLite fallback is critical when multiple Plugin instances run in the
+ * same process (e.g. opencode Desktop's local sidecar plus a connected
+ * `opencode serve` sharing the same DB). Each instance has its own
+ * MemberRegistry; without a SQLite fallback, a tool call dispatched to
+ * a Plugin instance whose registry never saw the spawn fails with
+ * "This session is not in a team."
+ *
+ * Only members in active teams with non-terminal status are resolved.
  */
 export function findTeamBySession(
   db: Database,
   registry: MemberRegistry,
   sessionId: string,
 ): { teamId: string; teamName: string; role: "lead" | "member"; memberName?: string } | undefined {
-  // Check if session is a team member
+  // Fast path: registry cache
   const entry = registry.getBySession(sessionId)
   if (entry) {
     const team = db.query("SELECT name FROM team WHERE id = ? AND status = 'active'").get(entry.teamId) as { name: string } | null
     if (team) return { teamId: entry.teamId, teamName: team.name, role: "member", memberName: entry.memberName }
   }
 
-  // Check if session is a team lead
+  // SQLite fallback: another Plugin instance may have registered this teammate
+  if (!entry) {
+    const memberRow = db.query(
+      `SELECT tm.team_id, tm.name as member_name, t.name as team_name
+       FROM team_member tm
+       JOIN team t ON tm.team_id = t.id
+       WHERE tm.session_id = ?
+         AND t.status = 'active'
+         AND tm.status NOT IN ('shutdown', 'error')`
+    ).get(sessionId) as { team_id: string; member_name: string; team_name: string } | null
+    if (memberRow) {
+      // Populate the cache so subsequent lookups skip the SQL query
+      registry.register(memberRow.team_id, memberRow.member_name, sessionId)
+      return { teamId: memberRow.team_id, teamName: memberRow.team_name, role: "member", memberName: memberRow.member_name }
+    }
+  }
+
+  // Check if session is a team lead (already SQLite-backed, naturally cross-instance)
   const leadTeam = db.query("SELECT id, name FROM team WHERE lead_session_id = ? AND status = 'active'").get(sessionId) as { id: string; name: string } | null
   if (leadTeam) return { teamId: leadTeam.id, teamName: leadTeam.name, role: "lead" }
 
@@ -99,7 +129,8 @@ export function findTeamBySession(
 /**
  * Get the session ID for a recipient by name.
  * "lead" resolves to the team's lead_session_id.
- * Otherwise looks up the member registry.
+ * Otherwise looks up the member via the registry, then falls back to SQLite
+ * (covers the multi-Plugin-instance scenario — see findTeamBySession).
  */
 export function resolveRecipientSession(
   db: Database,
@@ -112,5 +143,16 @@ export function resolveRecipientSession(
     return team?.lead_session_id
   }
   const entry = registry.getByName(teamId, recipientName)
-  return entry?.sessionId
+  if (entry) return entry.sessionId
+
+  // SQLite fallback: another Plugin instance may have registered this teammate
+  const memberRow = db.query(
+    `SELECT session_id FROM team_member
+     WHERE team_id = ? AND name = ? AND status NOT IN ('shutdown', 'error')`
+  ).get(teamId, recipientName) as { session_id: string } | null
+  if (!memberRow) return undefined
+
+  // Populate the cache
+  registry.register(teamId, recipientName, memberRow.session_id)
+  return memberRow.session_id
 }

--- a/src/watchdog.ts
+++ b/src/watchdog.ts
@@ -1,4 +1,4 @@
-import type { Database } from "bun:sqlite"
+import type { Database } from "./db"
 import type { PluginClient } from "./types"
 import type { MemberRegistry } from "./state"
 import type { ProgressTracker } from "./progress"

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test"
-import type { Database } from "bun:sqlite"
+import type { Database } from "../src/db"
 import { setupDb, insertTeam, insertMember } from "./helpers"
 import { startDashboard } from "../src/dashboard"
 

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -207,14 +207,25 @@ describe("dashboard", () => {
       // is that a new server can bind to the same port without waiting.
       expect(stopElapsed).toBeLessThan(500)
 
-      // Bind a new server on the same port immediately. Without
-      // closeAllConnections, the OS may still consider the port held.
-      const replacement = await Promise.race([
-        startDashboard(setupDb(), port),
-        new Promise<null>((_, reject) => setTimeout(() => reject(new Error("port still held")), 1000)),
-      ])
-      expect(replacement).toBeTruthy()
-      ;(replacement as unknown as { stop: (force?: boolean) => void } | null)?.stop(true)
+      // Probe the port directly with a fresh listener. Avoids racing the
+      // full dashboard startup against an arbitrary timer under CI load.
+      // Tries up to 3 times to absorb brief TIME_WAIT / cross-test races.
+      const tryProbe = async (): Promise<boolean> => {
+        const probe = net.createServer()
+        const ok = await new Promise<boolean>((resolve) => {
+          probe.once("error", () => resolve(false))
+          probe.listen(port, "127.0.0.1", () => resolve(true))
+        })
+        await new Promise<void>((r) => probe.close(() => r()))
+        return ok
+      }
+      let probeBound = await tryProbe()
+      for (let i = 0; !probeBound && i < 2; i++) {
+        await new Promise((r) => setTimeout(r, 50))
+        probeBound = await tryProbe()
+      }
+
+      expect(probeBound).toBe(true)
     })
   })
 })

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -174,4 +174,47 @@ describe("dashboard", () => {
       expect(res.status).toBe(404)
     })
   })
+
+  describe("stop(force)", () => {
+    test("stop(true) closes in-flight sockets so the port frees up promptly", async () => {
+      server = await startDashboard(db, port)
+      expect(server).toBeTruthy()
+
+      // Open a raw TCP socket to the dashboard and leave it dangling.
+      // node:http with keep-alive will keep the listener busy until the
+      // keep-alive timeout if we only call server.close() — server.stop(true)
+      // must call closeAllConnections() to terminate this socket promptly.
+      const net = await import("node:net")
+      const dangling = await new Promise<import("node:net").Socket>((resolve, reject) => {
+        const sock = net.createConnection({ port, host: "127.0.0.1" }, () => {
+          sock.write("GET /api/health HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n")
+        })
+        sock.on("error", reject)
+        sock.once("data", () => resolve(sock))
+      })
+
+      // Forcefully stop within a short window. server.close() alone would
+      // wait for the keep-alive socket to drain (default 5s in node:http).
+      const stopStart = Date.now()
+      server!.stop(true)
+      server = null
+      const stopElapsed = Date.now() - stopStart
+
+      // Cleanup the dangling socket
+      dangling.destroy()
+
+      // The synchronous stop() call returns immediately — the assertion
+      // is that a new server can bind to the same port without waiting.
+      expect(stopElapsed).toBeLessThan(500)
+
+      // Bind a new server on the same port immediately. Without
+      // closeAllConnections, the OS may still consider the port held.
+      const replacement = await Promise.race([
+        startDashboard(setupDb(), port),
+        new Promise<null>((_, reject) => setTimeout(() => reject(new Error("port still held")), 1000)),
+      ])
+      expect(replacement).toBeTruthy()
+      ;(replacement as unknown as { stop: (force?: boolean) => void } | null)?.stop(true)
+    })
+  })
 })

--- a/test/desktop-runtime.test.ts
+++ b/test/desktop-runtime.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { pathToFileURL } from "node:url"
+
+const tempDirs: string[] = []
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "opencode-ensemble-desktop-"))
+  tempDirs.push(dir)
+  return dir
+}
+
+async function buildForNode(entrypoint: string, outdir: string): Promise<string> {
+  const result = await Bun.build({
+    entrypoints: [entrypoint],
+    outdir,
+    target: "node",
+  })
+
+  if (!result.success) {
+    const logs = result.logs.map((log) => log.message).join("\n")
+    throw new Error(`Node build failed:\n${logs}`)
+  }
+
+  return path.join(outdir, `${path.basename(entrypoint, path.extname(entrypoint))}.js`)
+}
+
+async function runNode(modulePath: string): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(["node", "--no-warnings", modulePath], {
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+
+  return { exitCode, stdout, stderr }
+}
+
+async function runBun(modulePath: string): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn([process.execPath, modulePath], {
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+
+  return { exitCode, stdout, stderr }
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe("Desktop runtime compatibility", () => {
+  test("package build targets the Node-compatible runtime", async () => {
+    const pkg = await Bun.file("package.json").json() as { scripts?: Record<string, string> }
+
+    expect(pkg.scripts?.build).toContain("--target node")
+    expect(pkg.scripts?.build).not.toContain("--target bun")
+  })
+
+  test("full plugin bundle imports under Node's ESM loader", async () => {
+    const outdir = await createTempDir()
+    const bundlePath = await buildForNode(path.join(process.cwd(), "src/index.ts"), outdir)
+    const importScript = path.join(outdir, "import-plugin.mjs")
+
+    await Bun.write(
+      importScript,
+      `await import(${JSON.stringify(pathToFileURL(bundlePath).href)})\nconsole.log("plugin-loaded")\n`,
+    )
+
+    const result = await runNode(importScript)
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stderr).toBe("")
+    expect(result.stdout).toContain("plugin-loaded")
+  })
+
+  test("Node-targeted plugin bundle has no Bun-only runtime references", async () => {
+    const outdir = await createTempDir()
+    const bundlePath = await buildForNode(path.join(process.cwd(), "src/index.ts"), outdir)
+    const bundle = await Bun.file(bundlePath).text()
+
+    expect(bundle).not.toContain("bun:sqlite")
+    expect(bundle).not.toContain("Bun.")
+  })
+
+  test("Node-targeted plugin bundle still imports under Bun", async () => {
+    const outdir = await createTempDir()
+    const bundlePath = await buildForNode(path.join(process.cwd(), "src/index.ts"), outdir)
+    const importScript = path.join(outdir, "import-plugin.mjs")
+
+    await Bun.write(
+      importScript,
+      `await import(${JSON.stringify(pathToFileURL(bundlePath).href)})\nconsole.log("plugin-loaded")\n`,
+    )
+
+    const result = await runBun(importScript)
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stderr).toBe("")
+    expect(result.stdout).toContain("plugin-loaded")
+  })
+
+  test("SQLite adapter opens and migrates a database under Node", async () => {
+    const outdir = await createTempDir()
+    const entrypoint = path.join(outdir, "sqlite-entry.ts")
+    const dbPath = path.join(process.cwd(), "src/db.ts")
+    const dbImport = path.relative(outdir, dbPath).replaceAll(path.sep, "/")
+
+    await Bun.write(
+      entrypoint,
+      `import { createDb } from ${JSON.stringify(dbImport)}\nconst db = createDb(":memory:")\nconst version = db.query("PRAGMA user_version").get()\nif (!version || typeof version !== "object" || !("user_version" in version) || version.user_version < 1) {\n  throw new Error("migrations did not run")\n}\ndb.close()\nconsole.log("sqlite-ok")\n`,
+    )
+
+    const bundlePath = await buildForNode(entrypoint, outdir)
+    const result = await runNode(bundlePath)
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stderr).toBe("")
+    expect(result.stdout).toContain("sqlite-ok")
+  })
+})

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,11 +1,12 @@
 import { Database } from "bun:sqlite"
+import type { Database as EnsembleDatabase } from "../src/db"
 import { applyMigrations } from "../src/schema"
 import { MemberRegistry, DescendantTracker, PendingPurgeApprovals } from "../src/state"
 import type { ToolDeps, PluginClient } from "../src/types"
 import { DEFAULT_CONFIG } from "../src/config"
 
 /** Create a fresh in-memory DB with migrations applied. */
-export function setupDb(): Database {
+export function setupDb(): EnsembleDatabase {
   const db = new Database(":memory:")
   db.exec("PRAGMA journal_mode=WAL")
   db.exec("PRAGMA foreign_keys=ON")
@@ -83,7 +84,7 @@ export function mockClient(): PluginClient & { calls: Array<{ method: string; ar
 }
 
 /** Create full ToolDeps for testing. */
-export function setupDeps(db?: Database): ToolDeps & { client: ReturnType<typeof mockClient> } {
+export function setupDeps(db?: EnsembleDatabase): ToolDeps & { client: ReturnType<typeof mockClient> } {
   const d = db ?? setupDb()
   return {
     db: d,
@@ -97,7 +98,7 @@ export function setupDeps(db?: Database): ToolDeps & { client: ReturnType<typeof
 }
 
 /** Insert a team directly into the DB. */
-export function insertTeam(db: Database, id: string, name: string, leadSession: string, status = "active") {
+export function insertTeam(db: EnsembleDatabase, id: string, name: string, leadSession: string, status = "active") {
   db.run(
     "INSERT INTO team (id, name, lead_session_id, status, delegate, time_created, time_updated) VALUES (?, ?, ?, ?, 0, ?, ?)",
     [id, name, leadSession, status, Date.now(), Date.now()]
@@ -105,7 +106,7 @@ export function insertTeam(db: Database, id: string, name: string, leadSession: 
 }
 
 /** Insert a member directly into the DB. */
-export function insertMember(db: Database, teamId: string, name: string, sessionId: string, status = "ready", execStatus = "idle") {
+export function insertMember(db: EnsembleDatabase, teamId: string, name: string, sessionId: string, status = "ready", execStatus = "idle") {
   db.run(
     "INSERT INTO team_member (team_id, name, session_id, agent, status, execution_status, time_created, time_updated) VALUES (?, ?, ?, 'build', ?, ?, ?, ?)",
     [teamId, name, sessionId, status, execStatus, Date.now(), Date.now()]

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -876,3 +876,111 @@ describe("checkToolIsolation — SQLite fallback for multi-instance scenarios", 
       .toThrow("Team tools are not available to sub-agents")
   })
 })
+
+describe("handleSessionErrorEvent — SQLite fallback when registry is empty", () => {
+  let db: Database
+  let registry: MemberRegistry
+
+  beforeEach(() => {
+    db = setupDb()
+    registry = new MemberRegistry()
+  })
+
+  test("posts a system message via SQLite fallback when registry is empty", () => {
+    // Multi-Plugin-instance: SQLite has the teammate but this Plugin
+    // instance's in-memory registry never saw the spawn.
+    insertTeam(db, "t1", "smoke", "lead-sess")
+    insertMember(db, "t1", "scout", "scout-sess", "busy", "running")
+
+    handleSessionErrorEvent(db, registry, "scout-sess", {
+      name: "UnknownError",
+      data: { message: "Tool team_message failed" },
+    })
+
+    const msgs = db.query(
+      "SELECT from_name, to_name, content FROM team_message WHERE team_id = ?"
+    ).all("t1") as Array<{ from_name: string; to_name: string; content: string }>
+    expect(msgs).toHaveLength(1)
+    expect(msgs[0]?.from_name).toBe("system")
+    expect(msgs[0]?.to_name).toBe("lead")
+    expect(msgs[0]?.content).toContain("scout")
+  })
+
+  test("populates the registry cache after SQLite fallback", () => {
+    insertTeam(db, "t1", "smoke", "lead-sess")
+    insertMember(db, "t1", "scout", "scout-sess", "busy", "running")
+
+    handleSessionErrorEvent(db, registry, "scout-sess", { name: "UnknownError", data: { message: "boom" } })
+
+    expect(registry.getBySession("scout-sess")?.memberName).toBe("scout")
+  })
+
+  test("ignores shutdown teammates even if SQLite has the row", () => {
+    insertTeam(db, "t1", "smoke", "lead-sess")
+    insertMember(db, "t1", "scout", "scout-sess", "shutdown", "completed")
+
+    handleSessionErrorEvent(db, registry, "scout-sess", { name: "UnknownError", data: { message: "boom" } })
+
+    const msgs = db.query("SELECT id FROM team_message").all() as unknown[]
+    expect(msgs).toHaveLength(0)
+  })
+
+  test("ignores error-state teammates even if SQLite has the row", () => {
+    insertTeam(db, "t1", "smoke", "lead-sess")
+    insertMember(db, "t1", "scout", "scout-sess", "error", "failed")
+
+    handleSessionErrorEvent(db, registry, "scout-sess", { name: "UnknownError", data: { message: "boom" } })
+
+    const msgs = db.query("SELECT id FROM team_message").all() as unknown[]
+    expect(msgs).toHaveLength(0)
+  })
+})
+
+describe("checkToolIsolation — registry fast-path performance", () => {
+  let db: Database
+  let registry: MemberRegistry
+  let tracker: DescendantTracker
+
+  beforeEach(() => {
+    db = setupDb()
+    registry = new MemberRegistry()
+    tracker = new DescendantTracker()
+  })
+
+  function instrumentedDb(real: Database): { db: typeof real; queryCount: () => number } {
+    let count = 0
+    const wrapper = {
+      query: (sql: string) => {
+        count++
+        return real.query(sql)
+      },
+      exec: real.exec.bind(real),
+      run: real.run.bind(real),
+      close: real.close.bind(real),
+      transaction: real.transaction.bind(real),
+    } as unknown as typeof real
+    return { db: wrapper, queryCount: () => count }
+  }
+
+  test("skips SQLite query when caller is in registry (fast path)", () => {
+    insertTeam(db, "t1", "smoke", "lead-sess")
+    insertMember(db, "t1", "alice", "alice-sess", "busy", "running")
+    registry.register("t1", "alice", "alice-sess")
+
+    const { db: spyDb, queryCount } = instrumentedDb(db as unknown as Parameters<typeof instrumentedDb>[0])
+
+    expect(() => checkToolIsolation(registry, tracker, "team_message", "alice-sess", spyDb as unknown as Database)).not.toThrow()
+    expect(queryCount()).toBe(0)
+  })
+
+  test("falls through to SQLite when caller is NOT in registry", () => {
+    insertTeam(db, "t1", "smoke", "lead-sess")
+    insertMember(db, "t1", "scout", "scout-sess", "busy", "running")
+    // Registry is empty for scout
+
+    const { db: spyDb, queryCount } = instrumentedDb(db as unknown as Parameters<typeof instrumentedDb>[0])
+
+    expect(() => checkToolIsolation(registry, tracker, "team_message", "scout-sess", spyDb as unknown as Database)).not.toThrow()
+    expect(queryCount()).toBeGreaterThan(0)
+  })
+})

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -678,3 +678,201 @@ describe("handleSessionErrorEvent", () => {
     expect(msgs).toHaveLength(0)
   })
 })
+
+// --- Multi-instance state partition: registry empty, SQLite is source of truth ---
+// When opencode runs multiple Plugin instances in one process (Desktop's local
+// sidecar + a connected WSL serve sharing the same SQLite DB), each instance
+// has its own MemberRegistry. A team_* tool call from a teammate may be
+// dispatched to a Plugin instance whose registry never saw the spawn.
+// findTeamBySession and resolveRecipientSession MUST fall back to SQLite.
+
+describe("findTeamBySession — SQLite fallback when registry is empty", () => {
+  let db: Database
+  let registry: MemberRegistry
+
+  beforeEach(() => {
+    db = setupDb()
+    registry = new MemberRegistry()
+  })
+
+  test("resolves a teammate session via SQLite when registry has no entry", () => {
+    // Simulate a teammate written to the DB by a different Plugin instance
+    insertTeam(db, "t1", "my-team", "lead-sess")
+    insertMember(db, "t1", "scout", "scout-sess", "busy", "running")
+    // Note: registry is intentionally empty — this Plugin instance never saw the spawn
+
+    const teamInfo = findTeamBySession(db, registry, "scout-sess")
+
+    expect(teamInfo).toBeTruthy()
+    expect(teamInfo!.role).toBe("member")
+    expect(teamInfo!.memberName).toBe("scout")
+    expect(teamInfo!.teamId).toBe("t1")
+    expect(teamInfo!.teamName).toBe("my-team")
+  })
+
+  test("populates the registry cache after a successful SQLite fallback", () => {
+    insertTeam(db, "t1", "my-team", "lead-sess")
+    insertMember(db, "t1", "scout", "scout-sess", "busy", "running")
+
+    findTeamBySession(db, registry, "scout-sess")
+
+    // Cache should now hold the entry so subsequent lookups don't re-query
+    const cached = registry.getBySession("scout-sess")
+    expect(cached).toBeTruthy()
+    expect(cached!.memberName).toBe("scout")
+    expect(cached!.teamId).toBe("t1")
+  })
+
+  test("does not return members of archived teams", () => {
+    db.run(
+      "INSERT INTO team (id, name, lead_session_id, status, delegate, time_created, time_updated) VALUES (?, ?, ?, 'archived', 0, ?, ?)",
+      ["t1", "old", "lead-sess", Date.now(), Date.now()]
+    )
+    insertMember(db, "t1", "scout", "scout-sess", "busy", "running")
+
+    expect(findTeamBySession(db, registry, "scout-sess")).toBeUndefined()
+  })
+
+  test("does not return shutdown members from SQLite", () => {
+    insertTeam(db, "t1", "my-team", "lead-sess")
+    insertMember(db, "t1", "scout", "scout-sess", "shutdown", "completed")
+
+    expect(findTeamBySession(db, registry, "scout-sess")).toBeUndefined()
+  })
+
+  test("does not return error members from SQLite", () => {
+    insertTeam(db, "t1", "my-team", "lead-sess")
+    insertMember(db, "t1", "scout", "scout-sess", "error", "failed")
+
+    expect(findTeamBySession(db, registry, "scout-sess")).toBeUndefined()
+  })
+
+  test("registry-hit fast path still works without SQLite query", () => {
+    insertTeam(db, "t1", "my-team", "lead-sess")
+    insertMember(db, "t1", "alice", "alice-sess", "busy", "running")
+    registry.register("t1", "alice", "alice-sess")
+
+    const teamInfo = findTeamBySession(db, registry, "alice-sess")
+
+    expect(teamInfo).toBeTruthy()
+    expect(teamInfo!.role).toBe("member")
+    expect(teamInfo!.memberName).toBe("alice")
+  })
+
+  test("returns undefined when neither registry nor DB knows the session", () => {
+    insertTeam(db, "t1", "my-team", "lead-sess")
+    expect(findTeamBySession(db, registry, "ghost-sess")).toBeUndefined()
+  })
+})
+
+describe("resolveRecipientSession — SQLite fallback when registry is empty", () => {
+  let db: Database
+  let registry: MemberRegistry
+
+  beforeEach(() => {
+    db = setupDb()
+    registry = new MemberRegistry()
+  })
+
+  test("resolves a member by name via SQLite when registry has no entry", async () => {
+    insertTeam(db, "t1", "my-team", "lead-sess")
+    insertMember(db, "t1", "scout", "scout-sess", "busy", "running")
+    // Note: registry intentionally empty
+
+    const { resolveRecipientSession } = await import("../src/types")
+    const sessionId = resolveRecipientSession(db, registry, "t1", "scout")
+
+    expect(sessionId).toBe("scout-sess")
+  })
+
+  test("populates the registry cache after a successful SQLite fallback", async () => {
+    insertTeam(db, "t1", "my-team", "lead-sess")
+    insertMember(db, "t1", "scout", "scout-sess", "busy", "running")
+
+    const { resolveRecipientSession } = await import("../src/types")
+    resolveRecipientSession(db, registry, "t1", "scout")
+
+    expect(registry.getByName("t1", "scout")?.sessionId).toBe("scout-sess")
+  })
+
+  test("registry-hit fast path still works", async () => {
+    insertTeam(db, "t1", "my-team", "lead-sess")
+    insertMember(db, "t1", "alice", "alice-sess", "busy", "running")
+    registry.register("t1", "alice", "alice-sess")
+
+    const { resolveRecipientSession } = await import("../src/types")
+    expect(resolveRecipientSession(db, registry, "t1", "alice")).toBe("alice-sess")
+  })
+
+  test("does not return shutdown members", async () => {
+    insertTeam(db, "t1", "my-team", "lead-sess")
+    insertMember(db, "t1", "scout", "scout-sess", "shutdown", "completed")
+
+    const { resolveRecipientSession } = await import("../src/types")
+    expect(resolveRecipientSession(db, registry, "t1", "scout")).toBeUndefined()
+  })
+
+  test("does not return error members", async () => {
+    insertTeam(db, "t1", "my-team", "lead-sess")
+    insertMember(db, "t1", "scout", "scout-sess", "error", "failed")
+
+    const { resolveRecipientSession } = await import("../src/types")
+    expect(resolveRecipientSession(db, registry, "t1", "scout")).toBeUndefined()
+  })
+
+  test("'lead' resolves to team.lead_session_id (unchanged behaviour)", async () => {
+    insertTeam(db, "t1", "my-team", "lead-sess")
+
+    const { resolveRecipientSession } = await import("../src/types")
+    expect(resolveRecipientSession(db, registry, "t1", "lead")).toBe("lead-sess")
+  })
+})
+
+describe("checkToolIsolation — SQLite fallback for multi-instance scenarios", () => {
+  let db: Database
+  let registry: MemberRegistry
+  let tracker: DescendantTracker
+
+  beforeEach(() => {
+    db = setupDb()
+    registry = new MemberRegistry()
+    tracker = new DescendantTracker()
+  })
+
+  test("blocks sub-agent of teammate even when registry is empty (SQLite fallback)", () => {
+    // Multi-instance scenario: this Plugin instance's registry is empty, but
+    // SQLite has the teammate. A sub-agent of that teammate must still be
+    // blocked from calling team tools.
+    insertTeam(db, "t1", "smoke", "lead-sess")
+    insertMember(db, "t1", "scout", "scout-sess", "busy", "running")
+    tracker.track("sub-agent-sess", "scout-sess")
+
+    expect(() => checkToolIsolation(registry, tracker, "team_message", "sub-agent-sess", db))
+      .toThrow("Team tools are not available to sub-agents")
+  })
+
+  test("allows team tools for the teammate's own session via SQLite fallback", () => {
+    insertTeam(db, "t1", "smoke", "lead-sess")
+    insertMember(db, "t1", "scout", "scout-sess", "busy", "running")
+    // Registry empty — but scout IS a teammate per SQLite
+
+    expect(() => checkToolIsolation(registry, tracker, "team_message", "scout-sess", db)).not.toThrow()
+  })
+
+  test("ignores shutdown teammates in SQLite — their sub-agents are not blocked", () => {
+    insertTeam(db, "t1", "smoke", "lead-sess")
+    insertMember(db, "t1", "scout", "scout-sess", "shutdown", "completed")
+    tracker.track("sub-agent-sess", "scout-sess")
+
+    expect(() => checkToolIsolation(registry, tracker, "team_message", "sub-agent-sess", db)).not.toThrow()
+  })
+
+  test("works without db param (backward compatible — registry only)", () => {
+    // Legacy call sites that don't pass db keep their existing behaviour
+    registry.register("t1", "alice", "sess-1")
+    tracker.track("sub-agent-sess", "sess-1")
+
+    expect(() => checkToolIsolation(registry, tracker, "team_message", "sub-agent-sess"))
+      .toThrow("Team tools are not available to sub-agents")
+  })
+})

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach } from "bun:test"
 import { Database } from "bun:sqlite"
 import { applyMigrations } from "../src/schema"
 import { MemberRegistry, DescendantTracker } from "../src/state"
-import { handleSessionStatusEvent, handleSessionCreatedEvent, checkToolIsolation, shouldNudgeIdleMember } from "../src/hooks"
+import { handleSessionStatusEvent, handleSessionCreatedEvent, checkToolIsolation, shouldNudgeIdleMember, handleSessionErrorEvent } from "../src/hooks"
 import { buildLeadSystemPrompt, buildTeammateSystemPrompt, buildTeamCompactionContext } from "../src/system-prompt"
 import { findTeamBySession } from "../src/types"
 import { sendMessage } from "../src/messaging"
@@ -602,5 +602,79 @@ describe("buildTeamCompactionContext — completion requirement", () => {
   test("lead compaction context does NOT include reporting requirement", () => {
     const ctx = buildTeamCompactionContext(db, "t1", "lead")
     expect(ctx).not.toContain("before stopping")
+  })
+})
+
+describe("handleSessionErrorEvent", () => {
+  let db: Database
+  let registry: MemberRegistry
+
+  beforeEach(() => {
+    db = setupDb()
+    registry = new MemberRegistry()
+    insertTeam(db, "t1", "smoke", "lead-sess")
+    insertMember(db, "t1", "scout", "scout-sess", "busy", "running")
+    registry.register("t1", "scout", "scout-sess")
+  })
+
+  test("posts a system message to the lead when a known member errors", () => {
+    handleSessionErrorEvent(db, registry, "scout-sess", {
+      name: "UnknownError",
+      data: { message: "Tool team_message failed: This session is not in a team." },
+    })
+
+    const msgs = db.query(
+      "SELECT from_name, to_name, content FROM team_message WHERE team_id = ?"
+    ).all("t1") as Array<{ from_name: string; to_name: string; content: string }>
+    expect(msgs).toHaveLength(1)
+    expect(msgs[0]?.from_name).toBe("system")
+    expect(msgs[0]?.to_name).toBe("lead")
+    expect(msgs[0]?.content).toContain("scout")
+    expect(msgs[0]?.content).toContain("Tool team_message failed")
+  })
+
+  test("uses error.name as fallback when data.message is missing", () => {
+    handleSessionErrorEvent(db, registry, "scout-sess", { name: "ProviderAuthError" })
+
+    const msgs = db.query("SELECT content FROM team_message WHERE team_id = ?")
+      .all("t1") as Array<{ content: string }>
+    expect(msgs[0]?.content).toContain("ProviderAuthError")
+  })
+
+  test("uses 'unknown error' when error is undefined", () => {
+    handleSessionErrorEvent(db, registry, "scout-sess", undefined)
+
+    const msgs = db.query("SELECT content FROM team_message WHERE team_id = ?")
+      .all("t1") as Array<{ content: string }>
+    expect(msgs[0]?.content).toContain("unknown error")
+  })
+
+  test("ignores errors for unknown sessions (not in registry)", () => {
+    handleSessionErrorEvent(db, registry, "stranger-sess", {
+      name: "UnknownError",
+      data: { message: "boom" },
+    })
+
+    const msgs = db.query("SELECT id FROM team_message").all() as unknown[]
+    expect(msgs).toHaveLength(0)
+  })
+
+  test("ignores undefined sessionID", () => {
+    handleSessionErrorEvent(db, registry, undefined, { name: "UnknownError", data: { message: "boom" } })
+
+    const msgs = db.query("SELECT id FROM team_message").all() as unknown[]
+    expect(msgs).toHaveLength(0)
+  })
+
+  test("does not post a duplicate message for the lead — leads are not in registry", () => {
+    // The lead's session is NOT in the registry (leads are looked up via SQLite).
+    // A session.error for the lead's session should not produce a teammate-error message.
+    handleSessionErrorEvent(db, registry, "lead-sess", {
+      name: "UnknownError",
+      data: { message: "boom" },
+    })
+
+    const msgs = db.query("SELECT id FROM team_message").all() as unknown[]
+    expect(msgs).toHaveLength(0)
   })
 })

--- a/test/readme-social-preview.test.ts
+++ b/test/readme-social-preview.test.ts
@@ -40,7 +40,7 @@ describe("README social preview", () => {
   test("uses the bumped plugin version in install snippets", () => {
     const readme = readFileSync(readmePath, "utf8");
 
-    expect(readme).toContain("@hueyexe/opencode-ensemble@0.14.1");
+    expect(readme).toContain("@hueyexe/opencode-ensemble@0.14.2");
     expect(readme).not.toContain("@hueyexe/opencode-ensemble@0.14.0");
   });
 });

--- a/test/recovery.test.ts
+++ b/test/recovery.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeEach } from "bun:test"
 import { Database } from "bun:sqlite"
 import { applyMigrations } from "../src/schema"
-import { recoverStaleMembers, recoverUndeliveredMessages } from "../src/recovery"
+import { recoverStaleMembers, recoverUndeliveredMessages, rehydrateRegistry } from "../src/recovery"
 import type { PluginClient } from "../src/types"
 import { MemberRegistry } from "../src/state"
 import { sendMessage, broadcastMessage } from "../src/messaging"
@@ -380,5 +380,97 @@ describe("recoverOrphanedWorktrees", () => {
     const { recoverOrphanedWorktrees } = await import("../src/recovery")
     const result = await recoverOrphanedWorktrees(db, client)
     expect(result.removed).toBe(1) // second one succeeded
+  })
+})
+
+describe("rehydrateRegistry", () => {
+  let db: Database
+  let registry: MemberRegistry
+
+  beforeEach(() => {
+    db = setupDb()
+    registry = new MemberRegistry()
+  })
+
+  test("rehydrates an idle (ready) member from SQLite — the desktop bug", () => {
+    // This is the exact scenario from the production bug:
+    // a teammate exists in SQLite at status='ready' from a previous plugin
+    // lifetime, the plugin restarts, the registry is empty. Without
+    // rehydration, the teammate's team_* tool calls fail with "This
+    // session is not in a team."
+    insertTeam(db, "t1", "smoke", "lead-sess")
+    insertMember(db, "t1", "scout", "scout-sess", "ready", "idle")
+
+    const count = rehydrateRegistry(db, registry)
+
+    expect(count).toBe(1)
+    const entry = registry.getBySession("scout-sess")
+    expect(entry?.memberName).toBe("scout")
+    expect(entry?.teamId).toBe("t1")
+  })
+
+  test("rehydrates a busy member (not just ready ones)", () => {
+    insertTeam(db, "t1", "smoke", "lead-sess")
+    insertMember(db, "t1", "scout", "scout-sess", "busy", "running")
+
+    const count = rehydrateRegistry(db, registry)
+
+    expect(count).toBe(1)
+    expect(registry.getBySession("scout-sess")?.memberName).toBe("scout")
+  })
+
+  test("skips members in terminal states (shutdown, error)", () => {
+    insertTeam(db, "t1", "smoke", "lead-sess")
+    insertMember(db, "t1", "alice", "alice-sess", "shutdown", "completed")
+    insertMember(db, "t1", "bob", "bob-sess", "error", "failed")
+    insertMember(db, "t1", "carol", "carol-sess", "ready", "idle")
+
+    const count = rehydrateRegistry(db, registry)
+
+    expect(count).toBe(1)
+    expect(registry.getBySession("alice-sess")).toBeUndefined()
+    expect(registry.getBySession("bob-sess")).toBeUndefined()
+    expect(registry.getBySession("carol-sess")?.memberName).toBe("carol")
+  })
+
+  test("skips members in archived teams", () => {
+    db.run(
+      "INSERT INTO team (id, name, lead_session_id, status, delegate, time_created, time_updated) VALUES (?, ?, ?, 'archived', 0, ?, ?)",
+      ["t1", "old", "lead-sess", Date.now(), Date.now()]
+    )
+    insertMember(db, "t1", "scout", "scout-sess", "ready", "idle")
+
+    const count = rehydrateRegistry(db, registry)
+
+    expect(count).toBe(0)
+    expect(registry.getBySession("scout-sess")).toBeUndefined()
+  })
+
+  test("returns 0 when no active teams exist", () => {
+    expect(rehydrateRegistry(db, registry)).toBe(0)
+  })
+
+  test("rehydrates members from multiple active teams", () => {
+    insertTeam(db, "t1", "alpha", "lead-1")
+    insertTeam(db, "t2", "beta", "lead-2")
+    insertMember(db, "t1", "scout", "scout-sess", "ready", "idle")
+    insertMember(db, "t2", "ranger", "ranger-sess", "busy", "running")
+
+    const count = rehydrateRegistry(db, registry)
+
+    expect(count).toBe(2)
+    expect(registry.getBySession("scout-sess")?.teamId).toBe("t1")
+    expect(registry.getBySession("ranger-sess")?.teamId).toBe("t2")
+  })
+
+  test("is idempotent — running twice does not duplicate or error", () => {
+    insertTeam(db, "t1", "smoke", "lead-sess")
+    insertMember(db, "t1", "scout", "scout-sess", "ready", "idle")
+
+    rehydrateRegistry(db, registry)
+    const count = rehydrateRegistry(db, registry)
+
+    expect(count).toBe(1)
+    expect(registry.getBySession("scout-sess")?.memberName).toBe("scout")
   })
 })

--- a/test/system-prompt.test.ts
+++ b/test/system-prompt.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeEach } from "bun:test"
 import { setupDb, insertTeam, insertMember } from "./helpers"
 import { buildLeadSystemPrompt, buildTeammateSystemPrompt, buildTeamCompactionContext } from "../src/system-prompt"
-import type { Database } from "bun:sqlite"
+import type { Database } from "../src/db"
 
 function insertTask(db: Database, teamId: string, id: string, status: string, priority = "medium") {
   db.run(


### PR DESCRIPTION
## Summary
- Build the plugin for Node/Electron and remove Bun-only runtime APIs from the published bundle.
- Add a runtime SQLite adapter that uses `bun:sqlite` on Bun and `node:sqlite` on Node/Electron.
- Update README/version metadata for v0.14.2 and add Desktop runtime regression coverage.

Fixes #15

## Test Plan
- [x] `bun run typecheck && bun test && bun run build`
- [x] `node --no-warnings -e 'await import("./dist/index.js"); console.log("node-import-ok")'`
- [x] `bun -e 'await import("./dist/index.js"); console.log("bun-import-ok")'`
- [x] `rg 'bun:sqlite|Bun\.' dist/index.js` returns no matches
- [x] Local Ensemble smoke via `team_create`, `team_status`, `team_tasks_add`, `team_tasks_list`, read-only `team_spawn`, `team_results`, `team_shutdown`, `team_cleanup`
- [x] OpenCode Desktop + WSL smoke confirmed by maintainer