### PR TITLE
feat: add verbose toggle for detailed agent interaction logs

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -22,7 +22,7 @@ function throwing(fn: SdkMethod): SdkMethod {
 
 /** Shape of the raw v2 SDK client — just the methods we wrap. */
 interface RawClient {
-  session: { create: SdkMethod; promptAsync: SdkMethod; abort: SdkMethod; status: SdkMethod }
+  session: { create: SdkMethod; promptAsync: SdkMethod; abort: SdkMethod; status: SdkMethod; messages: SdkMethod }
   tui: { showToast: SdkMethod; selectSession: SdkMethod }
   worktree: { create: SdkMethod; remove: SdkMethod; list: SdkMethod; reset: SdkMethod }
   experimental: { workspace: { create: SdkMethod; remove: SdkMethod; list: SdkMethod } }
@@ -40,6 +40,7 @@ export function wrapThrowingClient(raw: unknown): PluginClient {
       promptAsync: throwing(r.session.promptAsync.bind(r.session)),
       abort: throwing(r.session.abort.bind(r.session)),
       status: throwing(r.session.status.bind(r.session)),
+      messages: throwing(r.session.messages.bind(r.session)),
     },
     tui: {
       showToast: throwing(r.tui.showToast.bind(r.tui)),

--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -51,10 +51,10 @@ select{-webkit-appearance:none;appearance:none;background-image:url("data:image/
 <select id="sel" class="bg-base-900 border border-base-700 rounded-md px-2 py-[3px] text-[11px] text-txt-200 font-mono outline-none cursor-pointer hover:border-base-600 transition-colors max-w-[180px] sm:max-w-[320px] min-w-0"></select>
 </div>
     <div class="flex items-center gap-2 sm:gap-4 shrink-0">
-<label class="flex items-center gap-1.5 cursor-pointer select-none" id="vl" title="Toggle verbose mode — show full message content, auto-expand details, raw interaction logs">
+<button type="button" class="flex items-center gap-1.5 cursor-pointer select-none bg-transparent border-0 p-0" id="vb" aria-pressed="false" title="Toggle verbose mode — show full message content, auto-expand details, raw interaction logs">
 <span class="text-[10px] text-txt-400 uppercase tracking-wider hidden sm:inline">Verbose</span>
-<div class="w-8 h-4 rounded-full bg-base-700 relative transition-colors duration-200" id="vt"><div class="w-3.5 h-3.5 rounded-full bg-txt-400 absolute top-[1px] left-[1px] transition-all duration-200" id="vtk"></div></div>
-</label>
+<div class="w-8 h-4 rounded-full bg-base-700 relative transition-colors duration-200 pointer-events-none" id="vt"><div class="w-3.5 h-3.5 rounded-full bg-txt-400 absolute top-[1px] left-[1px] transition-all duration-200 pointer-events-none" id="vtk"></div></div>
+</button>
 <div id="hring" class="w-6 h-6 rounded-full" title="Team health"></div>
 <div class="flex items-center gap-2">
 <span id="clk" class="text-[11px] text-txt-400 font-mono"></span>

--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -50,7 +50,11 @@ select{-webkit-appearance:none;appearance:none;background-image:url("data:image/
 <span class="text-base-700">|</span>
 <select id="sel" class="bg-base-900 border border-base-700 rounded-md px-2 py-[3px] text-[11px] text-txt-200 font-mono outline-none cursor-pointer hover:border-base-600 transition-colors max-w-[180px] sm:max-w-[320px] min-w-0"></select>
 </div>
-<div class="flex items-center gap-2 sm:gap-4 shrink-0">
+    <div class="flex items-center gap-2 sm:gap-4 shrink-0">
+<label class="flex items-center gap-1.5 cursor-pointer select-none" id="vl" title="Toggle verbose mode — show full message content, auto-expand details, raw interaction logs">
+<span class="text-[10px] text-txt-400 uppercase tracking-wider hidden sm:inline">Verbose</span>
+<div class="w-8 h-4 rounded-full bg-base-700 relative transition-colors duration-200" id="vt"><div class="w-3.5 h-3.5 rounded-full bg-txt-400 absolute top-[1px] left-[1px] transition-all duration-200" id="vtk"></div></div>
+</label>
 <div id="hring" class="w-6 h-6 rounded-full" title="Team health"></div>
 <div class="flex items-center gap-2">
 <span id="clk" class="text-[11px] text-txt-400 font-mono"></span>
@@ -83,10 +87,11 @@ select{-webkit-appearance:none;appearance:none;background-image:url("data:image/
 <div class="bg-base-900 border border-base-800 rounded-lg p-6 max-w-sm" onclick="event.stopPropagation()">
 <div id="shortcuts-title" class="text-txt-200 font-semibold text-sm mb-4">Keyboard Shortcuts</div>
 <div class="grid grid-cols-2 gap-y-2 gap-x-6 text-[12px]">
-<div><kbd class="px-1.5 py-0.5 bg-base-800 rounded font-mono text-txt-300 text-[11px]">j</kbd> <span class="text-txt-400">Next agent</span></div>
+    <div><kbd class="px-1.5 py-0.5 bg-base-800 rounded font-mono text-txt-300 text-[11px]">j</kbd> <span class="text-txt-400">Next agent</span></div>
 <div><kbd class="px-1.5 py-0.5 bg-base-800 rounded font-mono text-txt-300 text-[11px]">k</kbd> <span class="text-txt-400">Prev agent</span></div>
 <div><kbd class="px-1.5 py-0.5 bg-base-800 rounded font-mono text-txt-300 text-[11px]">Enter</kbd> <span class="text-txt-400">Expand agent</span></div>
 <div><kbd class="px-1.5 py-0.5 bg-base-800 rounded font-mono text-txt-300 text-[11px]">Esc</kbd> <span class="text-txt-400">Collapse all</span></div>
+<div><kbd class="px-1.5 py-0.5 bg-base-800 rounded font-mono text-txt-300 text-[11px]">v</kbd> <span class="text-txt-400">Toggle verbose</span></div>
 <div><kbd class="px-1.5 py-0.5 bg-base-800 rounded font-mono text-txt-300 text-[11px]">1-9</kbd> <span class="text-txt-400">Switch team</span></div>
 <div><kbd class="px-1.5 py-0.5 bg-base-800 rounded font-mono text-txt-300 text-[11px]">?</kbd> <span class="text-txt-400">This help</span></div>
 </div>

--- a/src/dashboard-js-part1.ts
+++ b/src/dashboard-js-part1.ts
@@ -4,7 +4,7 @@ let S=null,selId=null,fails=0,pollT=Date.now(),prevMC=0,selCard=-1;
 let verbose=localStorage.getItem('ensemble-verbose')==='1';
 const expCards=new Set(),expMsgs=new Set();
 const E=s=>s?String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'):'';
-function toggleVerbose(){verbose=!verbose;localStorage.setItem('ensemble-verbose',verbose?'1':'0');var vt=document.getElementById('vt'),vtk=document.getElementById('vtk');if(vt&&vtk){vt.style.backgroundColor=verbose?'#3b82f6':'#2a3144';vtk.style.transform=verbose?'translateX(16px)':'translateX(0)';vtk.style.backgroundColor=verbose?'#fff':'#8a96aa'}render()}
+function toggleVerbose(){verbose=!verbose;localStorage.setItem('ensemble-verbose',verbose?'1':'0');var vt=document.getElementById('vt'),vtk=document.getElementById('vtk'),vb=document.getElementById('vb');if(vt&&vtk){vt.style.backgroundColor=verbose?'#3b82f6':'#2a3144';vtk.style.transform=verbose?'translateX(16px)':'translateX(0)';vtk.style.backgroundColor=verbose?'#fff':'#8a96aa'}if(vb)vb.setAttribute('aria-pressed',String(verbose));render()}
 const D=ms=>{const s=Math.floor(Math.abs(ms)/1000);return s<60?s+'s':s<3600?Math.floor(s/60)+'m':Math.floor(s/3600)+'h'};
 const T=e=>new Date(e).toLocaleTimeString('en-GB',{hour:'2-digit',minute:'2-digit',second:'2-digit'});
 function relT(ep){const ms=Date.now()-ep;if(ms<60000)return Math.floor(ms/1000)+'s ago';if(ms<3600000)return Math.floor(ms/60000)+'m ago';if(ms<86400000)return Math.floor(ms/3600000)+'h ago';return T(ep)}
@@ -117,7 +117,6 @@ function deriveSparkline(name,msgs){
   return '<svg class="inline-block text-blue-500/60" width="60" height="14" viewBox="0 0 60 14">'+bars+'</svg>';
 }
 
-function deriveVerboseLogs(name,msgs){return msgs.filter(function(m){return m.fromName===name||m.toName===name}).sort(function(a,b){return a.timeCreated-b.timeCreated})}
 function deriveTimeline(t){
   const ev=[];
   (t.members||[]).forEach(m=>{ev.push({t:m.timeCreated,type:'spawn',label:E(m.name)+' spawned',c:'bg-blue-400'});if(m.status==='shutdown')ev.push({t:m.timeUpdated,type:'off',label:E(m.name)+' shut down',c:'bg-txt-500'});if(m.status==='error')ev.push({t:m.timeUpdated,type:'err',label:E(m.name)+' error',c:'bg-red-500'})});

--- a/src/dashboard-js-part1.ts
+++ b/src/dashboard-js-part1.ts
@@ -1,8 +1,10 @@
 /** Dashboard JS — utilities, data helpers, and state management. */
 export const DASHBOARD_JS_PART1 = `
 let S=null,selId=null,fails=0,pollT=Date.now(),prevMC=0,selCard=-1;
+let verbose=localStorage.getItem('ensemble-verbose')==='1';
 const expCards=new Set(),expMsgs=new Set();
 const E=s=>s?String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'):'';
+function toggleVerbose(){verbose=!verbose;localStorage.setItem('ensemble-verbose',verbose?'1':'0');var vt=document.getElementById('vt'),vtk=document.getElementById('vtk');if(vt&&vtk){vt.style.backgroundColor=verbose?'#3b82f6':'#2a3144';vtk.style.transform=verbose?'translateX(16px)':'translateX(0)';vtk.style.backgroundColor=verbose?'#fff':'#8a96aa'}render()}
 const D=ms=>{const s=Math.floor(Math.abs(ms)/1000);return s<60?s+'s':s<3600?Math.floor(s/60)+'m':Math.floor(s/3600)+'h'};
 const T=e=>new Date(e).toLocaleTimeString('en-GB',{hour:'2-digit',minute:'2-digit',second:'2-digit'});
 function relT(ep){const ms=Date.now()-ep;if(ms<60000)return Math.floor(ms/1000)+'s ago';if(ms<3600000)return Math.floor(ms/60000)+'m ago';if(ms<86400000)return Math.floor(ms/3600000)+'h ago';return T(ep)}
@@ -115,6 +117,7 @@ function deriveSparkline(name,msgs){
   return '<svg class="inline-block text-blue-500/60" width="60" height="14" viewBox="0 0 60 14">'+bars+'</svg>';
 }
 
+function deriveVerboseLogs(name,msgs){return msgs.filter(function(m){return m.fromName===name||m.toName===name}).sort(function(a,b){return a.timeCreated-b.timeCreated})}
 function deriveTimeline(t){
   const ev=[];
   (t.members||[]).forEach(m=>{ev.push({t:m.timeCreated,type:'spawn',label:E(m.name)+' spawned',c:'bg-blue-400'});if(m.status==='shutdown')ev.push({t:m.timeUpdated,type:'off',label:E(m.name)+' shut down',c:'bg-txt-500'});if(m.status==='error')ev.push({t:m.timeUpdated,type:'err',label:E(m.name)+' error',c:'bg-red-500'})});

--- a/src/dashboard-js-part2.ts
+++ b/src/dashboard-js-part2.ts
@@ -69,9 +69,11 @@ function rAgents(t){
     const s=si(m.status),task=activeTaskFor(m.name,t.tasks||[]),msg=lastMessageFor(m.name,msgs),blocked=blockedTaskFor(m.name,t.tasks||[]);
     const d=D(n-m.timeUpdated),mi=msg?relT(msg.timeCreated):'\\u2014';
     const tt=task?.content,tr=tt&&tt.length>90?tt.slice(0,90)+'\\u2026':tt;
-    const mp=msg?(msg.content.length>90?msg.content.slice(0,90)+'\\u2026':msg.content):'';
+    const maxMsgLen=verbose?500:90;
+    const mp=msg?(msg.content.length>maxMsgLen?msg.content.slice(0,maxMsgLen)+'\\u2026':msg.content):'';
     const spark=deriveSparkline(m.name,msgs);
     const isSel=selCard===idx;
+    const verboseChips=verbose?chip('msgs '+(msgs.filter(function(x){return x.fromName===m.name}).length),'muted')+chip('updated '+d,'muted'):'';
     return '<button type="button" class="text-left rounded-lg border '+s.c+' p-3 transition-all duration-300 cursor-pointer hover:border-base-600 focus-visible:border-blue-400'+(isSel?' card-sel':'')+'" data-card="'+E(m.name)+'" onclick="openDrawer(this.dataset.card)" onkeydown="if(event.key===\\'Enter\\'||event.key===\\' \\'){event.preventDefault();openDrawer(this.dataset.card)}">'+
       '<div class="flex items-center gap-2">'+
         '<span class="w-[8px] h-[8px] rounded-full '+s.d+(m.status==='busy'?' pulse':'')+' shrink-0"></span>'+
@@ -81,11 +83,11 @@ function rAgents(t){
         '<span class="text-[10px] text-txt-500 ml-auto shrink-0">'+E(m.agent)+'</span>'+
         (m.model?chip(E(m.model),'muted'):'')+
       '</div>'+
-      (tr?'<div class="mt-2 text-[13px] text-txt-200 leading-snug truncate">'+(blocked?'<span class="text-amber-400">Blocked: </span>':'Current task: ')+E(tr)+'</div>':'<div class="mt-2 text-[13px] text-txt-500 leading-snug">No active task</div>')+
-      (mp?'<div class="mt-1 text-[12px] text-txt-400 truncate">Latest: '+E(mp)+'</div>':'')+
+      (tr?'<div class="mt-2 text-[13px] text-txt-200 leading-snug '+(verbose?'':'truncate')+'">'+(blocked?'<span class="text-amber-400">Blocked: </span>':'Current task: ')+E(tr)+'</div>':'<div class="mt-2 text-[13px] text-txt-500 leading-snug">No active task</div>')+
+      (mp?'<div class="mt-1 text-[12px] text-txt-400 '+(verbose?'':'truncate')+'">Latest: '+E(mp)+'</div>':'')+
       '<div class="mt-2 flex items-center gap-1.5 flex-wrap">'+
         chip('status '+d,'muted')+chip('msg '+mi,'muted')+chip(E(m.executionStatus||m.status),m.status==='busy'?'blue':m.status==='error'?'red':'muted')+
-        (m.worktreeBranch?chip(E(m.worktreeBranch),'muted'):'')+
+        (m.worktreeBranch?chip(E(m.worktreeBranch),'muted'):'')+verboseChips+
       '</div></button>';
   }).join('');
   patch(el,html);
@@ -98,7 +100,7 @@ function openDrawer(name){
   var h='';
   // Header
   h+='<div class="flex items-center justify-between mb-4">';
-  h+='<div class="flex items-center gap-2"><span class="w-[10px] h-[10px] rounded-full '+s.d+(m.status==='busy'?' pulse':'')+'"></span><h2 id="drawer-title" class="font-mono font-semibold text-[16px]">'+E(m.name)+'</h2><span class="text-[11px] px-2 py-[2px] rounded '+s.t+' bg-base-800/80">'+s.l+'</span></div>';
+  h+='<div class="flex items-center gap-2"><span class="w-[10px] h-[10px] rounded-full '+s.d+(m.status==='busy'?' pulse':'')+'"></span><h2 id="drawer-title" class="font-mono font-semibold text-[16px]">'+E(m.name)+'</h2><span class="text-[11px] px-2 py-[2px] rounded '+s.t+' bg-base-800/80">'+s.l+'</span>'+(verbose?'<span class="text-[10px] px-1.5 py-[1px] rounded bg-blue-500/15 text-blue-400 border border-blue-500/20">verbose</span>':'')+'</div>';
   h+='<button id="drawer-close" aria-label="Close agent detail" onclick="closeDrawer()" class="text-txt-500 hover:text-txt-200 transition-colors p-1"><svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg></button>';
   h+='</div>';
   // Meta chips
@@ -109,6 +111,7 @@ function openDrawer(name){
   if(m.planApproval&&m.planApproval!=='none')meta.push(chip(E(m.planApproval),m.planApproval==='approved'?'green':m.planApproval==='rejected'?'red':'amber'));
   meta.push(chip('spawned '+relT(m.timeCreated),'muted'));
   if(m.worktreeBranch)meta.push(chip(E(m.worktreeBranch),'muted'));
+  if(verbose){var vlogs=t.messages||[];meta.push(chip('total msgs: '+vlogs.length,'blue'));meta.push(chip('from agent: '+vlogs.filter(function(x){return x.fromName===name}).length,'blue'))}
   h+='<div class="flex flex-wrap gap-1.5 mb-4 pb-4 border-b border-base-800/50">'+meta.join('')+'</div>';
   // Prompt
   if(m.prompt){
@@ -140,11 +143,29 @@ function openDrawer(name){
       if(p){
         h+='<div class="mb-1">'+chip(E(p.status),p.status==='completed'?'green':'red')+' <span class="text-[13px] text-txt-200 font-medium">'+E(p.summary)+'</span></div>';
         if(p.details)h+='<div class="text-[12px] text-txt-300 md mt-2">'+md(p.details)+'</div>';
+        if(verbose&&p.details)h+='<details class="mt-2" open><summary class="text-[10px] text-txt-500 cursor-pointer select-none hover:text-txt-400">Raw content</summary><pre class="mt-1 text-[11px] text-txt-400 bg-base-950 rounded p-2 overflow-x-auto">'+E(am.content)+'</pre></details>';
       }else{
-        h+='<div class="text-[12px] text-txt-300 md">'+md(am.content)+'</div>';
+        if(verbose){h+='<div class="text-[12px] text-txt-300 md">'+md(am.content)+'</div>';h+='<details class="mt-1" open><summary class="text-[10px] text-txt-500 cursor-pointer select-none hover:text-txt-400">Raw</summary><pre class="mt-1 text-[11px] text-txt-400 bg-base-950 rounded p-2 overflow-x-auto">'+E(am.content)+'</pre></details>'}
+        else{h+='<div class="text-[12px] text-txt-300 md">'+md(am.content)+'</div>'}
       }
       h+='</div></div>';
     });
+  }
+  // Verbose interaction log
+  if(verbose){
+    h+='<div class="mt-4 pt-4 border-t border-base-800/50"><div class="text-txt-400 text-[10px] uppercase tracking-wider mb-3">Verbose Interaction Log <span class="text-txt-500 normal-case">(raw task results and tool calls)</span></div>';
+    var teamMsgs=(t.messages||[]).sort(function(a,b){return a.timeCreated-b.timeCreated});
+    teamMsgs.forEach(function(tm){
+      var tag='';
+      if(tm.fromName===name)tag='<span class="text-blue-400">sent</span>';
+      else if(tm.toName===name)tag='<span class="text-emerald-400">received</span>';
+      else tag='<span class="text-txt-500">other</span>';
+      h+='<div class="mb-3 bg-base-900/50 rounded-lg p-3 border border-base-800/30">';
+      h+='<div class="flex items-center gap-1.5 mb-1.5"><span class="text-[10px] font-medium text-txt-300">'+E(tm.fromName)+'</span>'+chip(relT(tm.timeCreated),'muted')+tag+'</div>';
+      h+='<pre class="text-[11px] text-txt-400 whitespace-pre-wrap break-words bg-base-950 rounded p-2 max-h-[200px] overflow-y-auto">'+E(tm.content)+'</pre>';
+      h+='</div>';
+    });
+    h+='</div>';
   }
   var drawer=document.getElementById('drawer');
   drawer.innerHTML=h;
@@ -208,11 +229,12 @@ function rActivity(t){
   if(!msgs.length){patch(el,'<div class="text-txt-500 text-sm py-6 text-center">Waiting for agent messages...</div>');return}
   const sp=saveSc(el);
   const newCount=msgs.length,hasNew=newCount>prevMC&&prevMC>0;
-  let html='<div class="flex items-center gap-2 mb-3"><span class="text-[11px] text-txt-300 font-semibold uppercase tracking-wider">Activity feed</span>'+chip(msgs.length+' msgs','muted')+'</div>';
+  const maxShow=verbose?msgs.length:30;
+  let html='<div class="flex items-center gap-2 mb-3"><span class="text-[11px] text-txt-300 font-semibold uppercase tracking-wider">Activity feed</span>'+chip(msgs.length+' msgs','muted')+(verbose?chip('verbose','blue'):'')+'</div>';
   html+='<div class="max-h-[50vh] overflow-y-auto scroll space-y-2">';
-  msgs.slice(0,30).forEach(function(m,mi){
+  msgs.slice(0,maxShow).forEach(function(m,mi){
     const isNew=hasNew&&mi<(newCount-prevMC);
-    const isExp=expMsgs.has(m.id);
+    const isExp=verbose||expMsgs.has(m.id);
     const p=parseR(m.content);
     const deliv=m.delivered?(m.read?'\\u2713\\u2713':'\\u2713'):'';
     const isFromAgent=m.fromName!=='lead'&&m.fromName!=='system';
@@ -221,7 +243,8 @@ function rActivity(t){
     const bubbleBg=isPeer?'bg-violet-500/[0.06] border-violet-500/15':isFromAgent?'bg-blue-500/[0.06] border-blue-500/15':'bg-base-800/40 border-base-700/30';
     const initial=m.fromName.charAt(0).toUpperCase();
     const avatarColor=m.fromName==='system'?'bg-amber-500/20 text-amber-400':isPeer?'bg-violet-500/20 text-violet-400':isFromAgent?'bg-blue-500/20 text-blue-400':'bg-emerald-500/20 text-emerald-400';
-    html+='<div class="'+align+(isNew?' hl':'')+' cursor-pointer" role="button" tabindex="0" aria-expanded="'+(isExp?'true':'false')+'" data-msg="'+E(m.id)+'" onclick="toggleMsg(this.dataset.msg)" onkeydown="if(event.key===\\'Enter\\'||event.key===\\' \\'){event.preventDefault();toggleMsg(this.dataset.msg)}">';
+    const msgId=E(m.id);
+    html+='<div class="'+align+(isNew?' hl':'')+(verbose?'':' cursor-pointer')+'" role="button" tabindex="0" aria-expanded="'+(isExp?'true':'false')+'" data-msg="'+msgId+'" onclick="toggleMsg(this.dataset.msg)" onkeydown="if(event.key===\\'Enter\\'||event.key===\\' \\'){event.preventDefault();toggleMsg(this.dataset.msg)}">';
     html+='<div class="flex items-start gap-2">';
     html+='<span class="w-5 h-5 rounded-full '+avatarColor+' flex items-center justify-center text-[9px] font-semibold shrink-0 mt-0.5">'+E(initial)+'</span>';
     html+='<div class="flex-1 min-w-0 rounded-xl border '+bubbleBg+' px-3 py-2">';
@@ -235,13 +258,15 @@ function rActivity(t){
       html+='<div>'+chip(E(p.status),p.status==='completed'?'green':'red')+' <span class="text-[13px] text-txt-200">'+E(p.summary)+'</span></div>';
       if(isExp&&p.details)html+='<div class="mt-2 text-[12px] text-txt-300 md">'+md(p.details)+'</div>';
       if(!isExp&&p.details)html+='<div class="mt-1 text-[10px] text-txt-500">Click to expand details</div>';
+      if(verbose&&p.details)html+='<details class="mt-2" open><summary class="text-[10px] text-txt-500 cursor-pointer select-none hover:text-txt-400">Raw</summary><pre class="mt-1 text-[11px] text-txt-400 bg-base-950 rounded p-2 overflow-x-auto max-h-[120px]">'+E(m.content)+'</pre></details>';
     }else{
-      if(isExp){html+='<div class="text-[12px] text-txt-300 md">'+md(m.content)+'</div>'}
+      if(isExp||verbose){html+='<div class="text-[12px] text-txt-300 md">'+md(m.content)+'</div>'}
       else{const preview=m.content.length>120?m.content.slice(0,120)+'\\u2026':m.content;html+='<div class="text-[13px] text-txt-300 truncate">'+E(preview)+'</div>'}
+      if(verbose)html+='<details class="mt-1" open><summary class="text-[10px] text-txt-500 cursor-pointer select-none hover:text-txt-400">Raw</summary><pre class="mt-1 text-[11px] text-txt-400 bg-base-950 rounded p-2 overflow-x-auto max-h-[120px]">'+E(m.content)+'</pre></details>';
     }
     html+='</div></div></div>';
   });
-  if(msgs.length>30)html+='<div class="text-center text-[10px] text-txt-500 py-2">+'+(msgs.length-30)+' older messages</div>';
+  if(msgs.length>maxShow)html+='<div class="text-center text-[10px] text-txt-500 py-2">+'+(msgs.length-maxShow)+' older messages</div>';
   html+='</div>';
   prevMC=newCount;
   el.innerHTML=html;

--- a/src/dashboard-js-part2.ts
+++ b/src/dashboard-js-part2.ts
@@ -65,6 +65,7 @@ function rAgents(t){
   const el=document.getElementById('agents'),mm=t.members||[];
   if(!mm.length){patch(el,'<div class="col-span-full text-center py-12"><div class="text-txt-400 text-sm mb-1">No agents yet</div><div class="text-txt-500 text-[11px]">Spawn teammates with <code class="px-1 py-0.5 bg-base-900 rounded font-mono text-[10px]">team_spawn</code></div></div>');return}
   const n=Date.now(),msgs=t.messages||[],sorted=[...mm].sort((a,b)=>rankAgent(a,b,t));
+  const msgCounts={};if(verbose){msgs.forEach(function(x){if(x.fromName){msgCounts[x.fromName]=(msgCounts[x.fromName]||0)+1}})}
   const html=sorted.map((m,idx)=>{
     const s=si(m.status),task=activeTaskFor(m.name,t.tasks||[]),msg=lastMessageFor(m.name,msgs),blocked=blockedTaskFor(m.name,t.tasks||[]);
     const d=D(n-m.timeUpdated),mi=msg?relT(msg.timeCreated):'\\u2014';
@@ -73,7 +74,7 @@ function rAgents(t){
     const mp=msg?(msg.content.length>maxMsgLen?msg.content.slice(0,maxMsgLen)+'\\u2026':msg.content):'';
     const spark=deriveSparkline(m.name,msgs);
     const isSel=selCard===idx;
-    const verboseChips=verbose?chip('msgs '+(msgs.filter(function(x){return x.fromName===m.name}).length),'muted')+chip('updated '+d,'muted'):'';
+    const verboseChips=verbose?chip('msgs '+(msgCounts[m.name]||0),'muted')+chip('updated '+d,'muted'):'';
     return '<button type="button" class="text-left rounded-lg border '+s.c+' p-3 transition-all duration-300 cursor-pointer hover:border-base-600 focus-visible:border-blue-400'+(isSel?' card-sel':'')+'" data-card="'+E(m.name)+'" onclick="openDrawer(this.dataset.card)" onkeydown="if(event.key===\\'Enter\\'||event.key===\\' \\'){event.preventDefault();openDrawer(this.dataset.card)}">'+
       '<div class="flex items-center gap-2">'+
         '<span class="w-[8px] h-[8px] rounded-full '+s.d+(m.status==='busy'?' pulse':'')+' shrink-0"></span>'+
@@ -154,7 +155,7 @@ function openDrawer(name){
   // Verbose interaction log
   if(verbose){
     h+='<div class="mt-4 pt-4 border-t border-base-800/50"><div class="text-txt-400 text-[10px] uppercase tracking-wider mb-3">Verbose Interaction Log <span class="text-txt-500 normal-case">(raw task results and tool calls)</span></div>';
-    var teamMsgs=(t.messages||[]).sort(function(a,b){return a.timeCreated-b.timeCreated});
+    var teamMsgs=[...(t.messages||[])].sort(function(a,b){return a.timeCreated-b.timeCreated});
     teamMsgs.forEach(function(tm){
       var tag='';
       if(tm.fromName===name)tag='<span class="text-blue-400">sent</span>';
@@ -244,7 +245,11 @@ function rActivity(t){
     const initial=m.fromName.charAt(0).toUpperCase();
     const avatarColor=m.fromName==='system'?'bg-amber-500/20 text-amber-400':isPeer?'bg-violet-500/20 text-violet-400':isFromAgent?'bg-blue-500/20 text-blue-400':'bg-emerald-500/20 text-emerald-400';
     const msgId=E(m.id);
-    html+='<div class="'+align+(isNew?' hl':'')+(verbose?'':' cursor-pointer')+'" role="button" tabindex="0" aria-expanded="'+(isExp?'true':'false')+'" data-msg="'+msgId+'" onclick="toggleMsg(this.dataset.msg)" onkeydown="if(event.key===\\'Enter\\'||event.key===\\' \\'){event.preventDefault();toggleMsg(this.dataset.msg)}">';
+    if(verbose){
+      html+='<div class="'+align+(isNew?' hl':'')+'">';
+    }else{
+      html+='<div class="'+align+(isNew?' hl':'')+' cursor-pointer" role="button" tabindex="0" aria-expanded="'+(isExp?'true':'false')+'" data-msg="'+msgId+'" onclick="toggleMsg(this.dataset.msg)" onkeydown="if(event.key===\\'Enter\\'||event.key===\\' \\'){event.preventDefault();toggleMsg(this.dataset.msg)}">';
+    }
     html+='<div class="flex items-start gap-2">';
     html+='<span class="w-5 h-5 rounded-full '+avatarColor+' flex items-center justify-center text-[9px] font-semibold shrink-0 mt-0.5">'+E(initial)+'</span>';
     html+='<div class="flex-1 min-w-0 rounded-xl border '+bubbleBg+' px-3 py-2">';

--- a/src/dashboard-js-part2.ts
+++ b/src/dashboard-js-part2.ts
@@ -168,6 +168,11 @@ function openDrawer(name){
     });
     h+='</div>';
   }
+  // Session conversation (verbose mode only)
+  if(verbose&&m.sessionId){
+    var scId='sc-'+E(m.name);
+    h+='<div class="mt-4 pt-4 border-t border-base-800/50"><div class="text-txt-400 text-[10px] uppercase tracking-wider mb-3">Session Conversation <span class="text-txt-500 normal-case">(full agent thinking, tool calls, reasoning)</span></div><div id="'+scId+'"><div class="text-txt-500 text-[12px]">Loading...</div></div></div>';
+  }
   var drawer=document.getElementById('drawer');
   drawer.innerHTML=h;
   drawer.classList.add('open');
@@ -176,6 +181,68 @@ function openDrawer(name){
   setBackgroundInert(true);
   drawer.focus();
   document.getElementById('drawer-bg').classList.add('open');
+  // Fetch session conversation after drawer is rendered
+  if(verbose&&m.sessionId){
+    fetchSessionConvo(m.sessionId,'sc-'+E(m.name));
+  }
+}
+
+function renderSessionConvo(msgs){
+  if(!msgs||!msgs.length) return '<div class="text-txt-500 text-[12px]">No conversation history available</div>';
+  return msgs.map(function(m){
+    var isUser=m.info.role==='user';
+    var align=isUser?'mr-6':'ml-6';
+    var bubbleBg=isUser?'bg-emerald-500/[0.06] border-emerald-500/15':'bg-violet-500/[0.06] border-violet-500/15';
+    var label=isUser?'Prompt':'Response';
+    if(m.info.agent) label+=' ('+E(m.info.agent)+')';
+    var partsHtml='';
+    if(m.parts&&m.parts.length){
+      partsHtml=m.parts.map(function(p){
+        if(p.type==='text') return '<div class="text-[12px] text-txt-300 md mt-1">'+(p.text?md(p.text):'')+'</div>';
+        if(p.type==='reasoning') return '<details class="mt-1"><summary class="text-[10px] text-txt-500 cursor-pointer select-none hover:text-txt-400">Reasoning</summary><pre class="mt-1 text-[11px] text-txt-400 bg-base-950 rounded p-2 overflow-x-auto whitespace-pre-wrap">'+(p.text?E(p.text):'')+'</pre></details>';
+        if(p.type==='step-start') return '<div class="text-[11px] text-txt-500 mt-1 italic">Step: '+E(p.label||p.step||'')+'</div>';
+        if(p.type==='step-finish') return '<div class="text-[11px] text-txt-500 mt-1 italic">Completed: '+E(p.label||'')+'</div>';
+        if(p.type==='tool'){
+          var st=p.state||{};
+          var pn=p.tool||'tool';
+          var ps=st.status||'called';
+          var pi=st.input||'';
+          var pr=st.output||st.error||'';
+          var pd='';
+          if(pi) pd+='<div class="text-[10px] text-txt-500 mt-1">Input:</div><pre class="text-[11px] text-txt-400 bg-base-950 rounded p-2 overflow-x-auto whitespace-pre-wrap">'+E(typeof pi==='string'?pi:JSON.stringify(pi,null,2))+'</pre>';
+          if(pr) pd+='<div class="text-[10px] text-txt-500 mt-1">Result:</div><pre class="text-[11px] text-txt-400 bg-base-950 rounded p-2 overflow-x-auto whitespace-pre-wrap">'+E(typeof pr==='string'?pr:JSON.stringify(pr,null,2))+'</pre>';
+          return '<details class="mt-1"><summary class="text-[10px] text-txt-500 cursor-pointer select-none hover:text-txt-400">Tool: '+E(pn)+' ('+ps+')</summary>'+pd+'</details>';
+        }
+        if(p.type==='file'){
+          var fp=p.path||p.name||'';
+          var fc=p.content||p.diff||'';
+          return '<details class="mt-1"><summary class="text-[10px] text-txt-500 cursor-pointer select-none hover:text-txt-400">File: '+E(fp)+'</summary><pre class="mt-1 text-[11px] text-txt-400 bg-base-950 rounded p-2 overflow-x-auto whitespace-pre-wrap">'+E(fc)+'</pre></details>';
+        }
+        return '';
+      }).join('');
+    }
+    var meta='';
+    if(m.info.time) meta+=chip(T(m.info.time),'muted');
+    if(m.info.modelID) meta+=chip(E(m.info.modelID),'muted');
+    if(m.info.finish) meta+=chip(E(m.info.finish),m.info.finish==='stop'?'green':'muted');
+    if(m.info.tokens) meta+=chip('in:'+(m.info.tokens.input||0)+' out:'+(m.info.tokens.output||0),'muted');
+    return '<div class="mb-3 '+align+'"><div class="rounded-xl border '+bubbleBg+' p-3"><div class="flex items-center gap-1.5 mb-1.5 flex-wrap"><span class="text-[10px] font-medium '+(isUser?'text-emerald-400':'text-violet-400')+'">'+label+'</span>'+meta+'</div>'+partsHtml+'</div></div>';
+  }).join('');
+}
+
+async function fetchSessionConvo(sessionId,containerId){
+  var el=document.getElementById(containerId);
+  if(!el) return;
+  el.innerHTML='<div class="text-txt-500 text-[12px]">Loading session conversation...</div>';
+  try{
+    var res=await fetch('/api/session/'+encodeURIComponent(sessionId)+'/messages');
+    if(!res.ok){el.innerHTML='<div class="text-red-400 text-[12px]">Failed to load session conversation (HTTP '+res.status+')</div>';return}
+    var body=await res.json();
+    var msgs=body&&body.data?body.data:[];
+    el.innerHTML=renderSessionConvo(msgs);
+  }catch(e){
+    el.innerHTML='<div class="text-txt-500 text-[12px]">Could not load session conversation</div>';
+  }
 }
 
 function closeDrawer(){

--- a/src/dashboard-js-part3.ts
+++ b/src/dashboard-js-part3.ts
@@ -85,10 +85,11 @@ document.addEventListener('keydown',function(e){
 document.getElementById('sel').addEventListener('change',function(){selId=this.value;render()});
 
 // Verbose toggle
-document.getElementById('vl').addEventListener('click',function(e){e.preventDefault();toggleVerbose()});
+document.getElementById('vb').addEventListener('click',function(){toggleVerbose()});
+document.getElementById('vb').addEventListener('keydown',function(e){if(e.key==='Enter'||e.key===' '){e.preventDefault();toggleVerbose()}});
 
 // Initialize toggle visual state
-(function(){var vt=document.getElementById('vt'),vtk=document.getElementById('vtk');if(vt&&vtk){vt.style.backgroundColor=verbose?'#3b82f6':'#2a3144';vtk.style.transform=verbose?'translateX(16px)':'translateX(0)';vtk.style.backgroundColor=verbose?'#fff':'#8a96aa'}})();
+(function(){var vt=document.getElementById('vt'),vtk=document.getElementById('vtk'),vb=document.getElementById('vb');if(vt&&vtk){vt.style.backgroundColor=verbose?'#3b82f6':'#2a3144';vtk.style.transform=verbose?'translateX(16px)':'translateX(0)';vtk.style.backgroundColor=verbose?'#fff':'#8a96aa'}if(vb)vb.setAttribute('aria-pressed',String(verbose));})();
 
 // Initial poll
 poll();

--- a/src/dashboard-js-part3.ts
+++ b/src/dashboard-js-part3.ts
@@ -15,7 +15,7 @@ function conn(ok){
   document.getElementById('ct').textContent=ok?D(Date.now()-pollT)+' ago':'reconnecting to dashboard state';
 }
 
-async function poll(){try{S=await(await fetch('/api/state')).json();fails=0;pollT=Date.now();conn(true);render()}catch{if(++fails>=3)conn(false)}}
+async function poll(){try{var url='/api/state'+(verbose?'?verbose=1':'');S=await(await fetch(url)).json();fails=0;pollT=Date.now();conn(true);render()}catch{if(++fails>=3)conn(false)}}
 
 function setBackgroundInert(locked){
   document.querySelectorAll('header,main,#sum,#tl').forEach(function(el){
@@ -72,6 +72,7 @@ document.addEventListener('keydown',function(e){
   if(e.key==='Escape'){closeDrawer();expMsgs.clear();selCard=-1;closeShortcuts();render();return}
   if(e.key==='j'&&mm.length){e.preventDefault();selCard=Math.min(selCard+1,mm.length-1);render();return}
   if(e.key==='k'&&mm.length){e.preventDefault();selCard=Math.max(selCard-1,0);render();return}
+  if(e.key==='v'&&!e.ctrlKey&&!e.metaKey){e.preventDefault();toggleVerbose();return}
   if(e.key==='Enter'&&selCard>=0&&selCard<mm.length){e.preventDefault();openDrawer(mm[selCard].name);return}
   if(e.key>='1'&&e.key<='9'){
     var teams=allTeams(),all=[...teams.active,...teams.archived];
@@ -82,6 +83,12 @@ document.addEventListener('keydown',function(e){
 
 // Select handler
 document.getElementById('sel').addEventListener('change',function(){selId=this.value;render()});
+
+// Verbose toggle
+document.getElementById('vl').addEventListener('click',function(e){e.preventDefault();toggleVerbose()});
+
+// Initialize toggle visual state
+(function(){var vt=document.getElementById('vt'),vtk=document.getElementById('vtk');if(vt&&vtk){vt.style.backgroundColor=verbose?'#3b82f6':'#2a3144';vtk.style.transform=verbose?'translateX(16px)':'translateX(0)';vtk.style.backgroundColor=verbose?'#fff':'#8a96aa'}})();
 
 // Initial poll
 poll();

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -4,6 +4,7 @@ import { DASHBOARD_JS_PART1 } from "./dashboard-js-part1"
 import { DASHBOARD_JS_PART2 } from "./dashboard-js-part2"
 import { DASHBOARD_JS_PART3 } from "./dashboard-js-part3"
 import { log } from "./log"
+import type { PluginClient } from "./types"
 
 /** Assemble the full dashboard HTML from parts. */
 const DASHBOARD_HTML = DASHBOARD_HEAD + "\n<script>" + DASHBOARD_JS_PART1 + DASHBOARD_JS_PART2 + DASHBOARD_JS_PART3 + "<\/script>\n</body></html>"
@@ -20,6 +21,7 @@ interface TeamRow {
 interface MemberRow {
   name: string
   agent: string
+  session_id: string | null
   status: string
   execution_status: string
   worktree_branch: string | null
@@ -76,7 +78,7 @@ function parseDependsOn(value: string | null): string[] {
 function buildState(db: Database, verbose?: boolean): { teams: unknown[] } {
   const msgLimit = verbose ? 200 : 50
   const teams = db.query("SELECT id, name, status, lead_agent, time_created, time_updated FROM team ORDER BY time_created DESC").all() as TeamRow[]
-  const memberStmt = db.query("SELECT name, agent, status, execution_status, worktree_branch, prompt, model, plan_approval, time_created, time_updated FROM team_member WHERE team_id = ?")
+  const memberStmt = db.query("SELECT name, agent, session_id, status, execution_status, worktree_branch, prompt, model, plan_approval, time_created, time_updated FROM team_member WHERE team_id = ?")
   const taskStmt = db.query("SELECT id, content, status, priority, assignee, depends_on, time_created, time_updated FROM team_task WHERE team_id = ?")
   const msgStmt = db.query("SELECT id, from_name, to_name, content, delivered, read, time_created FROM team_message WHERE team_id = ? ORDER BY time_created DESC LIMIT ?")
 
@@ -91,6 +93,7 @@ function buildState(db: Database, verbose?: boolean): { teams: unknown[] } {
       members: (memberStmt.all(t.id) as MemberRow[]).map((m) => ({
         name: m.name,
         agent: m.agent,
+        sessionId: m.session_id,
         status: m.status,
         executionStatus: m.execution_status,
         worktreeBranch: m.worktree_branch,
@@ -129,7 +132,7 @@ function buildState(db: Database, verbose?: boolean): { teams: unknown[] } {
  * Singleton: if the port is already in use by another ensemble instance, skips silently.
  * Returns the server instance, or null if skipped.
  */
-export async function startDashboard(db: Database, port: number): Promise<ReturnType<typeof Bun.serve> | null> {
+export async function startDashboard(db: Database, port: number, client: PluginClient): Promise<ReturnType<typeof Bun.serve> | null> {
   try {
     const server = Bun.serve({
       port,
@@ -143,6 +146,16 @@ export async function startDashboard(db: Database, port: number): Promise<Return
         if (url.pathname === "/api/state") {
           const verbose = url.searchParams.get("verbose") === "1"
           return jsonResponse(buildState(db, verbose))
+        }
+
+        if (url.pathname.startsWith("/api/session/") && url.pathname.endsWith("/messages")) {
+          const sessionId = url.pathname.split("/")[3]
+          if (!sessionId) return new Response("Bad Request", { status: 400 })
+          return client.session.messages({ sessionID: sessionId }).then((result) => {
+            return jsonResponse(result)
+          }).catch((err) => {
+            return jsonResponse({ error: err instanceof Error ? err.message : String(err) }, 500)
+          })
         }
 
         if (url.pathname === "/") {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -73,11 +73,12 @@ function parseDependsOn(value: string | null): string[] {
   return []
 }
 
-function buildState(db: Database): { teams: unknown[] } {
+function buildState(db: Database, verbose?: boolean): { teams: unknown[] } {
+  const msgLimit = verbose ? 200 : 50
   const teams = db.query("SELECT id, name, status, lead_agent, time_created, time_updated FROM team ORDER BY time_created DESC").all() as TeamRow[]
   const memberStmt = db.query("SELECT name, agent, status, execution_status, worktree_branch, prompt, model, plan_approval, time_created, time_updated FROM team_member WHERE team_id = ?")
   const taskStmt = db.query("SELECT id, content, status, priority, assignee, depends_on, time_created, time_updated FROM team_task WHERE team_id = ?")
-  const msgStmt = db.query("SELECT id, from_name, to_name, content, delivered, read, time_created FROM team_message WHERE team_id = ? ORDER BY time_created DESC LIMIT 50")
+  const msgStmt = db.query("SELECT id, from_name, to_name, content, delivered, read, time_created FROM team_message WHERE team_id = ? ORDER BY time_created DESC LIMIT ?")
 
   return {
     teams: teams.map((t) => ({
@@ -109,7 +110,7 @@ function buildState(db: Database): { teams: unknown[] } {
         timeCreated: tk.time_created,
         timeUpdated: tk.time_updated,
       })),
-      messages: (msgStmt.all(t.id) as MessageRow[]).map((msg) => ({
+      messages: (msgStmt.all(t.id, msgLimit) as MessageRow[]).map((msg) => ({
         id: msg.id,
         fromName: msg.from_name,
         toName: msg.to_name,
@@ -140,7 +141,8 @@ export async function startDashboard(db: Database, port: number): Promise<Return
         }
 
         if (url.pathname === "/api/state") {
-          return jsonResponse(buildState(db))
+          const verbose = url.searchParams.get("verbose") === "1"
+          return jsonResponse(buildState(db, verbose))
         }
 
         if (url.pathname === "/") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ const plugin: Plugin = async (input) => {
 
     // Start dashboard server (main instance only, not worktree instances)
     if (config.dashboardPort !== 0) {
-      startDashboard(db, config.dashboardPort).catch((err) => {
+      startDashboard(db, config.dashboardPort, client).catch((err) => {
         log(`init:dashboard:failed err=${err instanceof Error ? err.message : String(err)}`)
       })
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,7 @@ export interface PluginClient {
       workspaceID?: string
       directory?: string
     }): Promise<{ data?: { id: string } }>
+    messages(options: { sessionID: string; directory?: string }): Promise<{ data?: unknown }>
     promptAsync(options: {
       sessionID: string
       parts: Array<{ type: "text"; text: string }>

--- a/test/client-shape.test.ts
+++ b/test/client-shape.test.ts
@@ -13,6 +13,7 @@ describe("v2 SDK client shape matches PluginClient", () => {
     expect(typeof client.session.promptAsync).toBe("function")
     expect(typeof client.session.abort).toBe("function")
     expect(typeof client.session.status).toBe("function")
+    expect(typeof client.session.messages).toBe("function")
   })
 
   test("tui methods exist", () => {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -10,6 +10,7 @@ function fakeSDK(overrides: Record<string, unknown> = {}) {
       promptAsync: overrides["session.promptAsync"] ?? (async () => ({ data: {} })),
       abort: overrides["session.abort"] ?? (async () => ({ data: {} })),
       status: overrides["session.status"] ?? (async () => ({ data: {} })),
+      messages: overrides["session.messages"] ?? (async () => ({ data: [] })),
     },
     tui: {
       showToast: overrides["tui.showToast"] ?? (async () => ({ data: {} })),
@@ -58,6 +59,7 @@ describe("wrapThrowingClient", () => {
     expect(typeof client.session.promptAsync).toBe("function")
     expect(typeof client.session.abort).toBe("function")
     expect(typeof client.session.status).toBe("function")
+    expect(typeof client.session.messages).toBe("function")
   })
 
   test("wraps all worktree methods", async () => {

--- a/test/dashboard-ui-contract.test.ts
+++ b/test/dashboard-ui-contract.test.ts
@@ -56,9 +56,10 @@ describe("dashboard UI contract", () => {
   })
 
   test("verbose toggle appears in header chrome", () => {
-    expect(DASHBOARD_HEAD).toContain('id="vl"')
+    expect(DASHBOARD_HEAD).toContain('id="vb"')
     expect(DASHBOARD_HEAD).toContain('id="vt"')
     expect(DASHBOARD_HEAD).toContain('id="vtk"')
+    expect(DASHBOARD_HEAD).toContain('aria-pressed')
     expect(DASHBOARD_HEAD).toContain("Toggle verbose mode")
   })
 

--- a/test/dashboard-ui-contract.test.ts
+++ b/test/dashboard-ui-contract.test.ts
@@ -115,4 +115,15 @@ describe("dashboard UI contract", () => {
   test("agent cards do not dim operational text with whole-card opacity", () => {
     expect(DASHBOARD_JS_PART2).not.toContain("opacity-50")
   })
+
+  test("session conversation render helpers are defined", () => {
+    expect(DASHBOARD_JS_PART2).toContain("function renderSessionConvo")
+    expect(DASHBOARD_JS_PART2).toContain("function fetchSessionConvo")
+    expect(DASHBOARD_JS_PART2).toContain("Session Conversation")
+    expect(DASHBOARD_JS_PART2).toContain("full agent thinking, tool calls, reasoning")
+  })
+
+  test("sessionId field appears in member data rendering", () => {
+    expect(DASHBOARD_JS_PART2).toContain("m.sessionId")
+  })
 })

--- a/test/dashboard-ui-contract.test.ts
+++ b/test/dashboard-ui-contract.test.ts
@@ -55,6 +55,17 @@ describe("dashboard UI contract", () => {
     expect(DASHBOARD_JS_PART3).toContain("e.key==='Escape'")
   })
 
+  test("verbose toggle appears in header chrome", () => {
+    expect(DASHBOARD_HEAD).toContain('id="vl"')
+    expect(DASHBOARD_HEAD).toContain('id="vt"')
+    expect(DASHBOARD_HEAD).toContain('id="vtk"')
+    expect(DASHBOARD_HEAD).toContain("Toggle verbose mode")
+  })
+
+  test("verbose toggle keyboard shortcut in shortcuts overlay", () => {
+    expect(DASHBOARD_HEAD).toContain("Toggle verbose")
+  })
+
   test("shortcut overlay exposes dialog semantics", () => {
     expect(DASHBOARD_HEAD).toContain('id="sco" role="dialog"')
     expect(DASHBOARD_HEAD).toContain('aria-modal="true"')

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -112,7 +112,7 @@ describe("dashboard", () => {
       expect(body.teams[0]!.status).toBe("archived")
     })
 
-    test("messages limited to last 50", async () => {
+    test("messages limited to last 50 by default", async () => {
       insertTeam(db, "t1", "alpha", "lead-sess")
       for (let i = 0; i < 60; i++) {
         insertMessage(db, "t1", `msg-${i}`, "alice", "lead", `Message ${i}`)
@@ -123,6 +123,19 @@ describe("dashboard", () => {
       const body = (await res.json()) as StateResponse
 
       expect(body.teams[0]!.messages).toHaveLength(50)
+    })
+
+    test("verbose returns up to 200 messages", async () => {
+      insertTeam(db, "t1", "alpha", "lead-sess")
+      for (let i = 0; i < 100; i++) {
+        insertMessage(db, "t1", `msg-${i}`, "alice", "lead", `Message ${i}`)
+      }
+
+      server = await startDashboard(db, port)
+      const res = await fetch(`http://localhost:${port}/api/state?verbose=1`)
+      const body = (await res.json()) as StateResponse
+
+      expect(body.teams[0]!.messages).toHaveLength(100)
     })
 
     test("returns multiple teams", async () => {

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -1,10 +1,15 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test"
 import type { Database } from "bun:sqlite"
-import { setupDb, insertTeam, insertMember } from "./helpers"
+import { setupDb, insertTeam, insertMember, mockClient } from "./helpers"
 import { startDashboard } from "../src/dashboard"
+import type { PluginClient } from "../src/types"
 
 function randomPort(): number {
   return 19000 + Math.floor(Math.random() * 10000)
+}
+
+function makeClient(): PluginClient & { calls: Array<{ method: string; args: unknown[] }> } {
+  return mockClient()
 }
 
 function insertTask(db: Database, teamId: string, id: string, content: string, status = "pending", priority = "medium", assignee: string | null = null, dependsOn: string | null = null) {
@@ -29,10 +34,12 @@ describe("dashboard", () => {
   let db: Database
   let port: number
   let server: Awaited<ReturnType<typeof startDashboard>>
+  let client: PluginClient & { calls: Array<{ method: string; args: unknown[] }> }
 
   beforeEach(() => {
     db = setupDb()
     port = randomPort()
+    client = makeClient()
   })
 
   afterEach(() => {
@@ -42,7 +49,7 @@ describe("dashboard", () => {
 
   describe("GET /api/health", () => {
     test("returns correct shape with ensemble: true", async () => {
-      server = await startDashboard(db, port)
+      server = await startDashboard(db, port, client)
       const res = await fetch(`http://localhost:${port}/api/health`)
       expect(res.status).toBe(200)
       expect(res.headers.get("content-type")).toContain("application/json")
@@ -55,7 +62,7 @@ describe("dashboard", () => {
 
   describe("GET /api/state", () => {
     test("returns empty teams array when no teams exist", async () => {
-      server = await startDashboard(db, port)
+      server = await startDashboard(db, port, client)
       const res = await fetch(`http://localhost:${port}/api/state`)
       expect(res.status).toBe(200)
       expect(res.headers.get("access-control-allow-origin")).toBe("*")
@@ -69,7 +76,7 @@ describe("dashboard", () => {
       insertTask(db, "t1", "task-1", "Fix auth", "in_progress", "high", "alice")
       insertMessage(db, "t1", "msg-1", "alice", "lead", "Done with auth fix")
 
-      server = await startDashboard(db, port)
+      server = await startDashboard(db, port, client)
       const res = await fetch(`http://localhost:${port}/api/state`)
       const body = (await res.json()) as StateResponse
 
@@ -85,6 +92,7 @@ describe("dashboard", () => {
       expect(team.members[0]!.name).toBe("alice")
       expect(team.members[0]!.agent).toBe("build")
       expect(team.members[0]!.status).toBe("busy")
+      expect(team.members[0]!.sessionId).toBe("sess-a")
       expect(team.members[0]!.executionStatus).toBe("running")
 
       expect(team.tasks).toHaveLength(1)
@@ -101,10 +109,21 @@ describe("dashboard", () => {
       expect(team.messages[0]!.content).toBe("Done with auth fix")
     })
 
+      test("returns member sessionId in state", async () => {
+      insertTeam(db, "t1", "alpha", "lead-sess")
+      insertMember(db, "t1", "alice", "sess-a", "busy", "running")
+
+      server = await startDashboard(db, port, client)
+      const res = await fetch(`http://localhost:${port}/api/state`)
+      const body = (await res.json()) as StateResponse
+
+      expect(body.teams[0]!.members[0]!.sessionId).toBe("sess-a")
+    })
+
     test("returns archived teams", async () => {
       insertTeam(db, "t1", "old-team", "lead-sess", "archived")
 
-      server = await startDashboard(db, port)
+      server = await startDashboard(db, port, client)
       const res = await fetch(`http://localhost:${port}/api/state`)
       const body = (await res.json()) as StateResponse
 
@@ -118,7 +137,7 @@ describe("dashboard", () => {
         insertMessage(db, "t1", `msg-${i}`, "alice", "lead", `Message ${i}`)
       }
 
-      server = await startDashboard(db, port)
+      server = await startDashboard(db, port, client)
       const res = await fetch(`http://localhost:${port}/api/state`)
       const body = (await res.json()) as StateResponse
 
@@ -131,7 +150,7 @@ describe("dashboard", () => {
         insertMessage(db, "t1", `msg-${i}`, "alice", "lead", `Message ${i}`)
       }
 
-      server = await startDashboard(db, port)
+      server = await startDashboard(db, port, client)
       const res = await fetch(`http://localhost:${port}/api/state?verbose=1`)
       const body = (await res.json()) as StateResponse
 
@@ -142,7 +161,7 @@ describe("dashboard", () => {
       insertTeam(db, "t1", "alpha", "lead-1")
       insertTeam(db, "t2", "beta", "lead-2")
 
-      server = await startDashboard(db, port)
+      server = await startDashboard(db, port, client)
       const res = await fetch(`http://localhost:${port}/api/state`)
       const body = (await res.json()) as StateResponse
 
@@ -154,7 +173,7 @@ describe("dashboard", () => {
       insertTask(db, "t1", "task-1", "Prepare dashboard contracts", "completed", "high")
       insertTask(db, "t1", "task-2", "Run final verification", "blocked", "high", null, JSON.stringify(["task-1"]))
 
-      server = await startDashboard(db, port)
+      server = await startDashboard(db, port, client)
       const res = await fetch(`http://localhost:${port}/api/state`)
       const body = (await res.json()) as StateResponse
 
@@ -164,7 +183,7 @@ describe("dashboard", () => {
 
   describe("GET /", () => {
     test("returns HTML content-type", async () => {
-      server = await startDashboard(db, port)
+      server = await startDashboard(db, port, client)
       const res = await fetch(`http://localhost:${port}/`)
       expect(res.status).toBe(200)
       expect(res.headers.get("content-type")).toContain("text/html")
@@ -180,9 +199,36 @@ describe("dashboard", () => {
     })
   })
 
+  describe("GET /api/session/:sessionId/messages", () => {
+    test("returns empty messages from SDK", async () => {
+      server = await startDashboard(db, port, client)
+      const res = await fetch(`http://localhost:${port}/api/session/sess-1/messages`)
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body).toEqual({ data: [] })
+    })
+
+    test("returns 500 when SDK call fails", async () => {
+      const failingClient = {
+        ...client,
+        session: {
+          ...client.session,
+          async messages() {
+            throw new Error("SDK error")
+          },
+        },
+      }
+      server = await startDashboard(db, port, failingClient as unknown as PluginClient)
+      const res = await fetch(`http://localhost:${port}/api/session/sess-1/messages`)
+      expect(res.status).toBe(500)
+      const body = await res.json()
+      expect(body.error).toBe("SDK error")
+    })
+  })
+
   describe("unknown routes", () => {
     test("returns 404", async () => {
-      server = await startDashboard(db, port)
+      server = await startDashboard(db, port, client)
       const res = await fetch(`http://localhost:${port}/nope`)
       expect(res.status).toBe(404)
     })

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -35,6 +35,10 @@ export function mockClient(): PluginClient & { calls: Array<{ method: string; ar
         calls.push({ method: "session.status", args: [] })
         return { data: {} }
       },
+      async messages(options) {
+        calls.push({ method: "session.messages", args: [options] })
+        return { data: [] }
+      },
     },
     tui: {
       async showToast(options) {

--- a/test/recovery.test.ts
+++ b/test/recovery.test.ts
@@ -37,6 +37,7 @@ function mockClient(): PluginClient & { calls: Array<{ method: string; args: unk
       async promptAsync(options) { calls.push({ method: "session.promptAsync", args: [options] }); return {} },
       async abort(options) { calls.push({ method: "session.abort", args: [options] }); return {} },
       async status() { calls.push({ method: "session.status", args: [] }); return { data: {} } },
+      async messages(options) { calls.push({ method: "session.messages", args: [options] }); return { data: [] } },
     },
     tui: {
       async showToast(options) { calls.push({ method: "tui.showToast", args: [options] }); return {} },


### PR DESCRIPTION
## Summary

Adds a "Verbose" toggle to the Ensemble dashboard for detailed agent interaction logs, plus surfaces the full session conversation of each agent — prompts, reasoning, tool calls, file diffs — directly in the dashboard UI.

## Changes

### Verbose Toggle (original)
- **Backend**: `GET /api/state?verbose=1` returns up to 200 messages per team (vs 50 default)
- **UI toggle**: Toggle switch in the dashboard header + `v` keyboard shortcut
- **Agent cards**: Show full message content instead of 90-char truncation
- **Activity feed**: Auto-expand all messages, show full content, show all messages (no 30 limit)
- **Agent drawer**: Raw message content shown alongside parsed task results; new "Verbose Interaction Log" section shows every team message with raw content
- **Persistence**: Preference saved to `localStorage`

### Session Conversation (new in this update)
- **Backend**: `GET /api/session/{sessionId}/messages` — new endpoint that proxies the SDK `session.messages()` through the dashboard server. The `sessionId` is now included in each member's state payload.
- **Agent drawer (verbose mode)**: New "Session Conversation" section at the bottom of the agent detail drawer. Fetches the agent's full session history asynchronously after the drawer opens.
- **Rendered parts**:
  - **Text** — user prompts and assistant responses, formatted with markdown
  - **Reasoning** — collapsible `<details>` blocks showing the model's chain-of-thought
  - **Step start/finish** — labeled step markers in italic
  - **Tool calls** — collapsible blocks showing tool name, status (pending/running/completed/error), input arguments (JSON formatted), and result output
  - **File parts** — collapsible blocks showing file path and content/diff

### Bug Fixes
- **ToolPart property paths**: Fixed `renderSessionConvo()` to use correct SDK property names (`p.tool` instead of `p.toolName`, `st.status` instead of `p.state`, `st.input` instead of `p.arguments`, `st.output`/`st.error` instead of `p.result`/`p.output`). Previously the summary showed `Tool: tool {[object Object]}` because `p.state` (the entire state object) was being stringified directly.
- **Dashboard session route**: Removed redundant duplicate `client.session.messages()` call that was firing a fire-and-forget request before the actual return.

## Verification

- `bun test` — 566 pass (3 new tests for verbose state, toggle HTML, keyboard shortcut)
- `bun run build` — 142 modules bundled in 84ms
- No type regressions

## Usage

Open the dashboard at `http://localhost:4747`, toggle verbose mode (toggle switch or `v` key), then click any agent card to open the detail drawer. The drawer shows:
1. **Original Prompt** — the task the agent was spawned with
2. **Conversation** — all team messages involving this agent, parsed and raw
3. **Verbose Interaction Log** — raw team message dump
4. **Session Conversation** — (verbose only) full session history with reasoning, tool calls, and file diffs

Closes #18
