### PR TITLE
Fix db naming for bun filters

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -43,7 +43,7 @@ class NodeSqliteAdapter implements Database {
   private readonly db: NodeSqliteDatabase
 
   constructor(filename: string) {
-    const sqlite = requireRuntimeModule("node:sqlite") as NodeSqliteModule
+    const sqlite = requireRuntimeModule(["node", "sqlite"].join(":")) as NodeSqliteModule
     this.db = new sqlite.DatabaseSync(filename)
   }
 


### PR DESCRIPTION
I've made this fix because bun scanner can fail.

The error 'better-sqlite3' is not yet supported in Bun came from Bun's static scanner detecting the literal string "node:sqlite" in requireRuntimeModule("node:sqlite") — even though it's dead code inside NodeSqliteAdapter (the class only instantiates on Node.js). Bun maps node:sqlite → better-sqlite3 internally and tries to resolve it at module load.
Fix: Changed the require to ["node", "sqlite"].join(":") — same pattern already used for bun:sqlite. Bun can't statically detect the dynamic string.