### PR TITLE
fix: use relative dashboard state path

### DIFF
--- a/src/dashboard-js-events.ts
+++ b/src/dashboard-js-events.ts
@@ -32,7 +32,7 @@ function conn(ok){
   document.getElementById('ct').textContent=ok?D(Date.now()-pollT)+' ago':'reconnecting to dashboard state';
 }
 
-async function poll(){try{S=await(await fetch('/api/state')).json();fails=0;pollT=Date.now();conn(true);render()}catch{if(++fails>=3)conn(false)}}
+async function poll(){try{S=await(await fetch('api/state')).json();fails=0;pollT=Date.now();conn(true);render()}catch{if(++fails>=3)conn(false)}}
 
 function setBackgroundInert(locked){
   document.querySelectorAll('header,main,#sum,#tl').forEach(function(el){

--- a/test/dashboard-ui-contract.test.ts
+++ b/test/dashboard-ui-contract.test.ts
@@ -74,6 +74,11 @@ describe("dashboard UI contract", () => {
     expect(DASHBOARD_JS_EVENTS).toContain("aria-hidden")
   })
 
+  test("dashboard polls state relative to the served page", () => {
+    expect(DASHBOARD_JS_EVENTS).toContain("fetch('api/state')")
+    expect(DASHBOARD_JS_EVENTS).not.toContain("fetch('/api/state')")
+  })
+
   test("agent prioritization helpers are defined", () => {
     expect(DASHBOARD_JS_CORE).toContain("function rankAgent")
     expect(DASHBOARD_JS_CORE).toContain("function deriveAttention")


### PR DESCRIPTION
## Summary

- change the dashboard state poll from an absolute `/api/state` request to a page-relative `api/state` request
- add a dashboard UI contract test so the frontend keeps using a relative state endpoint

## Why

When the dashboard is exposed through a subpath proxy such as Coder/code-server's `/proxy/<port>/`, the browser page can be served from `/proxy/4747/` while absolute `/api/state` escapes back to the domain root and returns 404. A relative request keeps the API under the same served base path while still resolving to `/api/state` on the normal `http://localhost:4747/` dashboard.

Closes #23.

## Validation

- `bun install --frozen-lockfile`
- `bun test test/dashboard-ui-contract.test.ts test/dashboard.test.ts`
- `bun run typecheck && bun test && bun run build` (624 tests passed)
- `bun run lint` (exit 0; existing warnings remain unrelated to this change)
- `git diff --check`
