### PR TITLE
fix(team-spawn): normalize nullish agent to build before spawning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -400,7 +400,7 @@ const plugin: Plugin = async (input) => {
           "Teammates work asynchronously and will message you when done. Do not poll for their status.",
         args: {
           name: tool.schema.string().describe("Teammate name (lowercase alphanumeric with hyphens)"),
-          agent: tool.schema.string().default("build").describe("Agent type (e.g. 'build', 'plan', 'explore')"),
+          agent: tool.schema.string().nullish().transform((v) => v ?? "build").describe("Agent type (e.g. 'build', 'plan', 'explore')"),
           prompt: tool.schema.string().describe("Task instructions for the teammate"),
           model: tool.schema.string().optional().describe("Model in provider/model format (optional, uses default)"),
           claim_task: tool.schema.string().optional().describe("Task ID to auto-claim for this teammate (optional)"),

--- a/src/tools/team-spawn.ts
+++ b/src/tools/team-spawn.ts
@@ -73,6 +73,10 @@ export async function executeTeamSpawn(
   const nameError = validateMemberName(args.name)
   if (nameError) throw new Error(nameError)
 
+  // Normalize the agent type.
+  const agent = args.agent ?? "build"
+  args = { ...args, agent }
+
   const teamInfo = requireLead(deps, sessionId)
 
   // Circuit breaker — stop retrying after 3 consecutive failures

--- a/test/tools/team-spawn.test.ts
+++ b/test/tools/team-spawn.test.ts
@@ -38,6 +38,20 @@ describe("team_spawn", () => {
     expect(promptCalls).toHaveLength(1)
   })
 
+  test("defaults agent to \"build\" when agent is null/undefined", async () => {
+    const result = await executeTeamSpawn(deps, {
+      name: "defaulted",
+      agent: undefined,
+      prompt: "Fix the tests",
+    } as unknown as Parameters<typeof executeTeamSpawn>[1], "lead-sess")
+
+    expect(result).toContain("defaulted")
+    expect(result).toContain("spawned")
+
+    const row = deps.db.query("SELECT agent FROM team_member WHERE name = ?").get("defaulted") as { agent: string }
+    expect(row.agent).toBe("build")
+  })
+
   test("rejects if caller is not the lead", async () => {
     insertMember(deps.db, "t1", "bob", "bob-sess")
     deps.registry.register("t1", "bob", "bob-sess")


### PR DESCRIPTION
## Summary

Fixes the `team_spawn` default agent handling when `agent` is `null` or `undefined`.

### Changes
- Accept `null` and `undefined` for the `agent` schema field and default to `"build"`.
- Normalize `args.agent` to `"build"` in `executeTeamSpawn` as a defensive fallback.
- Add a regression test covering the default agent behavior.

## Testing

- Added regression test for nullish `agent`.
- Verified that `agent` is persisted as `"build"` when omitted.
- `bun run typecheck && bun test && bun run build` — all green.

Closes #28 