### PR TITLE
fix: null-agent spawn crash and task status accuracy (#28, #27)

### DIFF
--- a/src/tools/team-claim.ts
+++ b/src/tools/team-claim.ts
@@ -1,5 +1,36 @@
+import type { Database } from "../db"
 import type { ToolDeps } from "../types"
 import { requireTeamMember } from "./shared"
+
+/**
+ * Atomically claim a pending task for an assignee. Sets status to
+ * 'in_progress' and records the assignee. Throws if the task is missing,
+ * blocked, already claimed, or no longer pending. Returns the task content
+ * on success.
+ *
+ * Shared by team_claim and team_spawn's claim_task auto-claim so both paths
+ * enforce the same atomic claim invariant.
+ */
+export function claimTask(db: Database, teamId: string, taskId: string, assignee: string): string {
+  const task = db.query("SELECT content, status, assignee FROM team_task WHERE id = ? AND team_id = ?")
+    .get(taskId, teamId) as { content: string; status: string; assignee: string | null } | null
+  if (!task) throw new Error(`Task "${taskId}" not found`)
+  if (task.status === "blocked") throw new Error(`Task "${taskId}" is blocked by unresolved dependencies`)
+  if (task.status !== "pending") throw new Error(`Task "${taskId}" is not pending (status: ${task.status})`)
+  if (task.assignee) throw new Error(`Task "${taskId}" is already claimed by ${task.assignee}`)
+
+  // Atomic claim: UPDATE only if still pending and unassigned
+  const result = db.run(
+    "UPDATE team_task SET status = 'in_progress', assignee = ?, time_updated = ? WHERE id = ? AND status = 'pending' AND assignee IS NULL",
+    [assignee, Date.now(), taskId]
+  )
+
+  if (result.changes === 0) {
+    throw new Error(`Task "${taskId}" is already claimed (race condition)`)
+  }
+
+  return task.content
+}
 
 /**
  * Execute the team_claim tool. Atomically claims a pending task.
@@ -13,23 +44,7 @@ export async function executeTeamClaim(
   const teamInfo = requireTeamMember(deps, sessionId)
 
   const claimerName = teamInfo.role === "lead" ? "lead" : (teamInfo.memberName ?? "unknown")
+  const content = claimTask(deps.db, teamInfo.teamId, args.task_id, claimerName)
 
-  const task = deps.db.query("SELECT * FROM team_task WHERE id = ? AND team_id = ?")
-    .get(args.task_id, teamInfo.teamId) as Record<string, unknown> | null
-  if (!task) throw new Error(`Task "${args.task_id}" not found`)
-  if (task.status === "blocked") throw new Error(`Task "${args.task_id}" is blocked by unresolved dependencies`)
-  if (task.status !== "pending") throw new Error(`Task "${args.task_id}" is not pending (status: ${task.status})`)
-  if (task.assignee) throw new Error(`Task "${args.task_id}" is already claimed by ${task.assignee}`)
-
-  // Atomic claim: UPDATE only if still pending and unassigned
-  const result = deps.db.run(
-    "UPDATE team_task SET status = 'in_progress', assignee = ?, time_updated = ? WHERE id = ? AND status = 'pending' AND assignee IS NULL",
-    [claimerName, Date.now(), args.task_id]
-  )
-
-  if (result.changes === 0) {
-    throw new Error(`Task "${args.task_id}" is already claimed (race condition)`)
-  }
-
-  return `Claimed task: ${task.content}`
+  return `Claimed task: ${content}`
 }

--- a/src/tools/team-spawn.ts
+++ b/src/tools/team-spawn.ts
@@ -1,6 +1,7 @@
 import type { ToolDeps, PermissionRule } from "../types"
 import { validateMemberName } from "../util"
 import { requireLead } from "./shared"
+import { claimTask } from "./team-claim"
 import { sendMessage } from "../messaging"
 import { log } from "../log"
 import type { EnsembleConfig } from "../config"
@@ -67,9 +68,14 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
  */
 export async function executeTeamSpawn(
   deps: ToolDeps,
-  args: { name: string; agent: string; prompt: string; model?: string; claim_task?: string; worktree?: boolean; plan_approval?: boolean },
+  args: { name: string; agent?: string | null; prompt: string; model?: string; claim_task?: string; worktree?: boolean; plan_approval?: boolean },
   sessionId: string,
 ): Promise<string> {
+  // Normalize agent: the tool schema defaults to "build", but Zod's .default()
+  // only fires on undefined — an explicit null slips through and would violate
+  // the team_member.agent NOT NULL constraint (issue #28).
+  const agent = args.agent ?? "build"
+
   const nameError = validateMemberName(args.name)
   if (nameError) throw new Error(nameError)
 
@@ -86,11 +92,11 @@ export async function executeTeamSpawn(
     .get(teamInfo.teamId, args.name)
   if (existing) throw new Error(`Teammate "${args.name}" already exists in team "${teamInfo.teamName}"`)
 
-  const isReadOnly = args.agent === "plan" || args.agent === "explore"
+  const isReadOnly = agent === "plan" || agent === "explore"
   const useWorktree = args.worktree !== false && !isReadOnly && !isWorktreeDirectory(deps.directory)
   const usePlanApproval = args.plan_approval === true
 
-  log(`spawn:start name=${args.name} agent=${args.agent} worktree=${useWorktree}`)
+  log(`spawn:start name=${args.name} agent=${agent} worktree=${useWorktree}`)
 
   // Create worktree if enabled
   let worktreeDir: string | null = null
@@ -177,7 +183,7 @@ export async function executeTeamSpawn(
     const createResult = await withTimeout(
       deps.client.session.create({
         parentID: sessionId,
-        title: `${args.name} (@${args.agent} teammate)`,
+        title: `${args.name} (@${agent} teammate)`,
         permission,
         ...(workspaceId ? { workspaceID: workspaceId } : {}),
       }),
@@ -216,22 +222,37 @@ export async function executeTeamSpawn(
   const now = Date.now()
   // Resolve model before DB insert so the stored value matches what promptAsync uses
   const memberCount = (deps.db.query("SELECT COUNT(*) as c FROM team_member WHERE team_id = ?").get(teamInfo.teamId) as { c: number }).c
-  const resolvedModel = resolveModel(args.model, args.agent, memberCount, deps.config)
+  const resolvedModel = resolveModel(args.model, agent, memberCount, deps.config)
   if (resolvedModel) log(`spawn:model name=${args.name} model=${resolvedModel}`)
 
   deps.db.run(
     `INSERT INTO team_member (team_id, name, session_id, agent, status, execution_status, model, prompt, worktree_dir, worktree_branch, workspace_id, plan_approval, time_created, time_updated)
      VALUES (?, ?, ?, ?, 'busy', 'starting', ?, ?, ?, ?, ?, ?, ?, ?)`,
-    [teamInfo.teamId, args.name, childSessionId, args.agent, resolvedModel ?? null, args.prompt, worktreeDir, worktreeBranch, workspaceId, planApproval, now, now]
+    [teamInfo.teamId, args.name, childSessionId, agent, resolvedModel ?? null, args.prompt, worktreeDir, worktreeBranch, workspaceId, planApproval, now, now]
   )
 
   // Register in memory
   deps.registry.register(teamInfo.teamId, args.name, childSessionId)
 
+  // Auto-claim a task for this teammate when claim_task is provided (issue #27).
+  // Claims atomically so a task is never double-assigned when the lead hands out
+  // more tasks than there are teammates. Read-only agents cannot claim tasks.
+  let claimedTaskContent: string | null = null
+  let claimWarning: string | null = null
+  if (args.claim_task && !isReadOnly) {
+    try {
+      claimedTaskContent = claimTask(deps.db, teamInfo.teamId, args.claim_task, args.name)
+      log(`spawn:claim:ok name=${args.name} task=${args.claim_task}`)
+    } catch (err) {
+      claimWarning = err instanceof Error ? err.message : String(err)
+      log(`spawn:claim:failed name=${args.name} task=${args.claim_task} err=${claimWarning}`)
+    }
+  }
+
   // Build teammate context message
   const context = [
     `You are "${args.name}", a teammate in team "${teamInfo.teamName}".`,
-    `Your agent type is "${args.agent}".`,
+    `Your agent type is "${agent}".`,
   ]
 
   // Show other teammates so this agent knows who to message
@@ -347,7 +368,7 @@ export async function executeTeamSpawn(
     args.prompt,
   )
 
-  if (args.claim_task) {
+  if (claimedTaskContent) {
     context.push("", `You have been assigned task ${args.claim_task}. Mark it complete when done.`)
   }
 
@@ -364,7 +385,7 @@ export async function executeTeamSpawn(
   deps.client.session.promptAsync({
     sessionID: childSessionId,
     parts: [{ type: "text", text: contextStr }],
-    agent: args.agent,
+    agent,
     ...(modelParam ? { model: modelParam } : {}),
   }).catch((err) => {
     const errMsg = err instanceof Error ? err.message : String(err)
@@ -372,6 +393,13 @@ export async function executeTeamSpawn(
     try {
       deps.db.run("DELETE FROM team_member WHERE team_id = ? AND session_id = ?", [teamInfo.teamId, childSessionId])
       deps.registry.unregister(childSessionId)
+      // Release any task auto-claimed for this teammate so it returns to the pool.
+      if (claimedTaskContent) {
+        deps.db.run(
+          "UPDATE team_task SET status = 'pending', assignee = NULL, time_updated = ? WHERE id = ? AND assignee = ?",
+          [Date.now(), args.claim_task, args.name]
+        )
+      }
       deps.client.session.abort({ sessionID: childSessionId }).catch(() => { /* best effort */ })
       if (workspaceId) {
         deps.client.workspace.remove({ id: workspaceId }).catch(() => { /* best effort */ })
@@ -397,8 +425,11 @@ export async function executeTeamSpawn(
 
   const branchInfo = worktreeBranch ? ` (branch: ${worktreeBranch})` : ""
   const planInfo = usePlanApproval ? " [plan mode — will send plan for approval]" : ""
+  const claimInfo = claimedTaskContent
+    ? ` (claimed task: ${args.claim_task})`
+    : claimWarning ? ` (could not claim task: ${claimWarning})` : ""
   // Reset circuit breaker on success
   spawnFailures.delete(teamInfo.teamId)
   log(`spawn:done name=${args.name} sessionId=${childSessionId}`)
-  return `Teammate "${args.name}" spawned (agent: ${args.agent})${branchInfo}${planInfo}. They are working on: ${args.prompt.slice(0, 120)}${args.prompt.length > 120 ? "..." : ""}`
+  return `Teammate "${args.name}" spawned (agent: ${agent})${branchInfo}${planInfo}${claimInfo}. They are working on: ${args.prompt.slice(0, 120)}${args.prompt.length > 120 ? "..." : ""}`
 }

--- a/src/tools/team-tasks-complete.ts
+++ b/src/tools/team-tasks-complete.ts
@@ -5,6 +5,12 @@ import { log } from "../log"
 /**
  * Execute the team_tasks_complete tool. Marks a task as completed
  * and unblocks any dependent tasks.
+ *
+ * Enforces task-board accuracy (issue #27):
+ * - Rejects completing an already-completed or cancelled task.
+ * - Rejects completing a blocked task (dependencies must resolve first).
+ * - Only the assignee (or the lead) may complete a claimed task.
+ * - Completing an unclaimed task attributes it to the caller atomically.
  */
 export async function executeTeamTasksComplete(
   deps: ToolDeps,
@@ -12,13 +18,31 @@ export async function executeTeamTasksComplete(
   sessionId: string,
 ): Promise<string> {
   const teamInfo = requireTeamMember(deps, sessionId)
+  const caller = teamInfo.role === "lead" ? "lead" : (teamInfo.memberName ?? "unknown")
 
-  const task = deps.db.query("SELECT * FROM team_task WHERE id = ? AND team_id = ?")
-    .get(args.task_id, teamInfo.teamId) as Record<string, unknown> | null
+  const task = deps.db.query("SELECT id, content, status, assignee FROM team_task WHERE id = ? AND team_id = ?")
+    .get(args.task_id, teamInfo.teamId) as { id: string; content: string; status: string; assignee: string | null } | null
   if (!task) throw new Error(`Task "${args.task_id}" not found`)
+  if (task.status === "completed") throw new Error(`Task "${args.task_id}" is already completed`)
+  if (task.status === "cancelled") throw new Error(`Task "${args.task_id}" was cancelled`)
+  if (task.status === "blocked") throw new Error(`Task "${args.task_id}" is blocked by unresolved dependencies`)
+  if (task.status === "in_progress" && task.assignee && teamInfo.role !== "lead" && caller !== task.assignee) {
+    throw new Error(`Task "${args.task_id}" is claimed by ${task.assignee}`)
+  }
 
   const now = Date.now()
-  deps.db.run("UPDATE team_task SET status = 'completed', time_updated = ? WHERE id = ?", [now, args.task_id])
+  if (task.assignee) {
+    deps.db.run("UPDATE team_task SET status = 'completed', time_updated = ? WHERE id = ?", [now, args.task_id])
+  } else {
+    // Attribute an unclaimed task to the caller so the board reflects who did it.
+    const result = deps.db.run(
+      "UPDATE team_task SET status = 'completed', assignee = ?, time_updated = ? WHERE id = ? AND assignee IS NULL",
+      [caller, now, args.task_id]
+    )
+    if (result.changes === 0) {
+      throw new Error(`Task "${args.task_id}" was just completed by another teammate`)
+    }
+  }
 
   // Unblock dependent tasks
   const allTasks = deps.db.query("SELECT id, depends_on, status FROM team_task WHERE team_id = ?")

--- a/test/tools/team-spawn.test.ts
+++ b/test/tools/team-spawn.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test"
 import { setupDeps, insertTeam, insertMember } from "../helpers"
 import { executeTeamSpawn } from "../../src/tools/team-spawn"
+import { executeTeamTasksAdd } from "../../src/tools/team-tasks-add"
 import type { ToolDeps } from "../../src/types"
 
 describe("team_spawn", () => {
@@ -36,6 +37,37 @@ describe("team_spawn", () => {
     expect(createCalls).toHaveLength(1)
     const promptCalls = deps.client.calls.filter(c => c.method === "session.promptAsync")
     expect(promptCalls).toHaveLength(1)
+  })
+
+  test("agent: null defaults to 'build' instead of hitting the NOT NULL constraint (issue #28)", async () => {
+    const result = await executeTeamSpawn(deps, {
+      name: "alice",
+      agent: null,
+      prompt: "Fix the tests",
+    }, "lead-sess")
+
+    expect(result).toContain("alice")
+    expect(result).toContain("spawned")
+
+    const row = deps.db.query("SELECT agent FROM team_member WHERE name = ?").get("alice") as { agent: string }
+    expect(row.agent).toBe("build")
+
+    const promptCall = deps.client.calls.find(c => c.method === "session.promptAsync")
+    const opts = promptCall!.args[0] as { agent?: string }
+    expect(opts.agent).toBe("build")
+  })
+
+  test("agent: undefined defaults to 'build'", async () => {
+    const result = await executeTeamSpawn(deps, {
+      name: "alice",
+      agent: undefined,
+      prompt: "Fix the tests",
+    }, "lead-sess")
+
+    expect(result).toContain("alice")
+
+    const row = deps.db.query("SELECT agent FROM team_member WHERE name = ?").get("alice") as { agent: string }
+    expect(row.agent).toBe("build")
   })
 
   test("rejects if caller is not the lead", async () => {
@@ -88,20 +120,45 @@ describe("team_spawn", () => {
     expect(text).toMatch(/mark.*complete.*team_message/s)
   })
 
-  test("context message includes assigned task when claim_task is provided", async () => {
+  test("claim_task atomically claims the task on the board and includes it in context", async () => {
+    const addResult = await executeTeamTasksAdd(deps, { tasks: [
+      { content: "Fix the login bug", priority: "high" },
+    ] }, "lead-sess")
+    const taskId = addResult.match(/task_\S+/)![0]!
+
     await executeTeamSpawn(deps, {
       name: "alice",
       agent: "build",
       prompt: "Fix the tests",
-      claim_task: "task-123",
+      claim_task: taskId,
     }, "lead-sess")
 
-    const promptCall = deps.client.calls.find(c => c.method === "session.promptAsync")
-    expect(promptCall).toBeTruthy()
-    const text = (promptCall!.args[0] as { parts: Array<{ text: string }> }).parts[0]!.text
+    // The task must be claimed (in_progress + assignee), not left pending.
+    const task = deps.db.query("SELECT status, assignee FROM team_task WHERE id = ?").get(taskId) as Record<string, string>
+    expect(task.status).toBe("in_progress")
+    expect(task.assignee).toBe("alice")
 
-    expect(text).toContain("task-123")
+    const promptCall = deps.client.calls.find(c => c.method === "session.promptAsync")
+    const text = (promptCall!.args[0] as { parts: Array<{ text: string }> }).parts[0]!.text
+    expect(text).toContain(taskId)
     expect(text).toContain("Mark it complete when done")
+  })
+
+  test("claim_task that cannot be claimed still spawns but does not inject assignment and warns", async () => {
+    const result = await executeTeamSpawn(deps, {
+      name: "alice",
+      agent: "build",
+      prompt: "Fix the tests",
+      claim_task: "task-does-not-exist",
+    }, "lead-sess")
+
+    expect(result).toContain("alice")
+    expect(result).toContain("spawned")
+    expect(result).toContain("could not claim task")
+
+    const promptCall = deps.client.calls.find(c => c.method === "session.promptAsync")
+    const text = (promptCall!.args[0] as { parts: Array<{ text: string }> }).parts[0]!.text
+    expect(text).not.toContain("You have been assigned task")
   })
 
   test("context message does NOT include assigned task line when claim_task is absent", async () => {

--- a/test/tools/team-tasks.test.ts
+++ b/test/tools/team-tasks.test.ts
@@ -241,4 +241,126 @@ describe("team_claim", () => {
     expect(fulfilled).toHaveLength(1)
     expect(rejected).toHaveLength(1)
   })
+
+  test("multiple members claim from a pool larger than member count — no double claims", async () => {
+    const addResult = await executeTeamTasksAdd(deps, { tasks: [
+      { content: "Task 1", priority: "high" },
+      { content: "Task 2", priority: "high" },
+      { content: "Task 3", priority: "high" },
+      { content: "Task 4", priority: "high" },
+    ] }, "sess-alice")
+    const ids = [...addResult.matchAll(/task_[a-z0-9_]+/g)].map(m => m[0]!)
+
+    // Two members race for four tasks, one task is contested by both.
+    const results = await Promise.allSettled([
+      executeTeamClaim(deps, { task_id: ids[0]! }, "sess-alice"),
+      executeTeamClaim(deps, { task_id: ids[0]! }, "sess-bob"),
+      executeTeamClaim(deps, { task_id: ids[1]! }, "sess-bob"),
+      executeTeamClaim(deps, { task_id: ids[2]! }, "sess-alice"),
+      executeTeamClaim(deps, { task_id: ids[3]! }, "sess-bob"),
+    ])
+
+    const fulfilled = results.filter(r => r.status === "fulfilled")
+    const rejected = results.filter(r => r.status === "rejected")
+    expect(fulfilled).toHaveLength(4)
+    expect(rejected).toHaveLength(1)
+
+    // Every task ends up claimed exactly once with a concrete assignee.
+    const rows = deps.db.query("SELECT status, assignee FROM team_task WHERE team_id = ?").all("t1") as Array<{ status: string; assignee: string | null }>
+    expect(rows).toHaveLength(4)
+    for (const t of rows) {
+      expect(t.status).toBe("in_progress")
+      expect(t.assignee).not.toBeNull()
+    }
+  })
+})
+
+describe("team_tasks_complete — ownership and state validation (issue #27)", () => {
+  let deps: ReturnType<typeof setupDeps>
+
+  beforeEach(() => {
+    deps = setupDeps()
+    insertTeam(deps.db, "t1", "my-team", "lead-sess")
+    insertMember(deps.db, "t1", "alice", "sess-alice")
+    insertMember(deps.db, "t1", "bob", "sess-bob")
+    deps.registry.register("t1", "alice", "sess-alice")
+    deps.registry.register("t1", "bob", "sess-bob")
+  })
+
+  test("a member cannot complete a task claimed by another member", async () => {
+    const r = await executeTeamTasksAdd(deps, { tasks: [{ content: "Shared task", priority: "high" }] }, "sess-alice")
+    const taskId = r.match(/task_\S+/)![0]!
+    await executeTeamClaim(deps, { task_id: taskId }, "sess-alice")
+
+    await expect(executeTeamTasksComplete(deps, { task_id: taskId }, "sess-bob"))
+      .rejects.toThrow("claimed by alice")
+
+    const row = deps.db.query("SELECT status, assignee FROM team_task WHERE id = ?").get(taskId) as Record<string, string>
+    expect(row.status).toBe("in_progress")
+    expect(row.assignee).toBe("alice")
+  })
+
+  test("completing an unclaimed pending task attributes it to the caller", async () => {
+    const r = await executeTeamTasksAdd(deps, { tasks: [{ content: "Unclaimed work", priority: "medium" }] }, "sess-alice")
+    const taskId = r.match(/task_\S+/)![0]!
+
+    const result = await executeTeamTasksComplete(deps, { task_id: taskId }, "sess-bob")
+    expect(result).toContain("Completed")
+
+    const row = deps.db.query("SELECT status, assignee FROM team_task WHERE id = ?").get(taskId) as Record<string, string>
+    expect(row.status).toBe("completed")
+    expect(row.assignee).toBe("bob")
+  })
+
+  test("completing an already-completed task is rejected", async () => {
+    const r = await executeTeamTasksAdd(deps, { tasks: [{ content: "Done task", priority: "high" }] }, "sess-alice")
+    const taskId = r.match(/task_\S+/)![0]!
+    await executeTeamClaim(deps, { task_id: taskId }, "sess-alice")
+    await executeTeamTasksComplete(deps, { task_id: taskId }, "sess-alice")
+
+    await expect(executeTeamTasksComplete(deps, { task_id: taskId }, "sess-alice"))
+      .rejects.toThrow("already completed")
+  })
+
+  test("completing a blocked task is rejected", async () => {
+    const rA = await executeTeamTasksAdd(deps, { tasks: [{ content: "Task A", priority: "high" }] }, "sess-alice")
+    const idA = rA.match(/task_\S+/)![0]!
+    const rB = await executeTeamTasksAdd(deps, { tasks: [{ content: "Task B", priority: "medium", depends_on: [idA] }] }, "sess-alice")
+    const idB = rB.match(/task_\S+/)![0]!
+
+    await expect(executeTeamTasksComplete(deps, { task_id: idB }, "sess-alice"))
+      .rejects.toThrow("blocked")
+  })
+
+  test("the lead can complete a task claimed by a member", async () => {
+    const r = await executeTeamTasksAdd(deps, { tasks: [{ content: "Lead-completed task", priority: "high" }] }, "sess-alice")
+    const taskId = r.match(/task_\S+/)![0]!
+    await executeTeamClaim(deps, { task_id: taskId }, "sess-alice")
+
+    const result = await executeTeamTasksComplete(deps, { task_id: taskId }, "lead-sess")
+    expect(result).toContain("Completed")
+    const row = deps.db.query("SELECT status FROM team_task WHERE id = ?").get(taskId) as Record<string, string>
+    expect(row.status).toBe("completed")
+  })
+
+  test("a multi-dependency task unblocks only after all dependencies complete", async () => {
+    const rA = await executeTeamTasksAdd(deps, { tasks: [{ content: "Task A", priority: "high" }] }, "sess-alice")
+    const idA = rA.match(/task_\S+/)![0]!
+    const rB = await executeTeamTasksAdd(deps, { tasks: [{ content: "Task B", priority: "high" }] }, "sess-alice")
+    const idB = rB.match(/task_\S+/)![0]!
+    const rC = await executeTeamTasksAdd(deps, { tasks: [{ content: "Task C", priority: "medium", depends_on: [idA, idB] }] }, "sess-alice")
+    const idC = rC.match(/task_\S+/)![0]!
+
+    // Complete A only — C must remain blocked while B is still pending.
+    await executeTeamClaim(deps, { task_id: idA }, "sess-alice")
+    await executeTeamTasksComplete(deps, { task_id: idA }, "sess-alice")
+    const cAfterA = deps.db.query("SELECT status FROM team_task WHERE id = ?").get(idC) as Record<string, string>
+    expect(cAfterA.status).toBe("blocked")
+
+    // Complete B — C must now unblock to pending.
+    await executeTeamClaim(deps, { task_id: idB }, "sess-bob")
+    await executeTeamTasksComplete(deps, { task_id: idB }, "sess-bob")
+    const cAfterB = deps.db.query("SELECT status FROM team_task WHERE id = ?").get(idC) as Record<string, string>
+    expect(cAfterB.status).toBe("pending")
+  })
 })


### PR DESCRIPTION
## Summary

Fixes two open bugs reported by users.

### #28 — `team_spawn` crashes when `agent` is null

Zod's `.default("build")` only fires on `undefined`, so an explicit `null` reached the `team_member.agent` NOT NULL column and threw `NOT NULL constraint failed: team_member.agent`.

**Fix:** normalize in `executeTeamSpawn` — `const agent = args.agent ?? "build"` — before any use. All downstream references (session title, DB insert, promptAsync agent, model resolution, context message) now use the normalized value.

### #27 — task status not always reflected accurately

Two root causes found:

1. **`claim_task` on `team_spawn` never actually claimed the task.** It only injected "You have been assigned task X" into the teammate prompt while the row stayed `pending`/unassigned — so with more tasks than teammates, the same task could be handed to multiple members and the board never reflected the assignment. The claim now goes through the same atomic claim path as `team_claim` (shared `claimTask()` helper, UPDATE-guarded against races), and the claim is released if the spawn's `promptAsync` fails (rollback).

2. **`team_tasks_complete` had no state/ownership checks.** Anyone could complete any task — including another member's claimed task, a blocked task, or an already-completed task — producing wrong `assignee`/`status` on the board. It now:
   - rejects completed/cancelled/blocked tasks
   - restricts claimed-task completion to the assignee (lead bypasses)
   - atomically attributes unclaimed completions to the caller

## Tests added (10)

- `agent: null` and `agent: undefined` → spawn with `build` (#28)
- `claim_task` atomically claims the task in DB; failed claim still spawns + warns + omits assignment line
- multiple members claim a 4-task pool concurrently — exactly one winner per task, no double claims
- member can't complete another member's claimed task; lead can
- unclaimed completion attributes assignee; already-completed and blocked completions rejected
- multi-dependency task unblocks only after all deps complete

## Verification

- `bun test` — **693 pass, 0 fail** (was 683)
- `bun run typecheck` — clean
- `bun run build` — clean
- `bun run lint` — 10 pre-existing warnings in untouched files only (dashboard/recovery/result-parser/team-cleanup); changed files clean

## Residual risks

- `team_tasks_complete` is stricter: a teammate completing another member's claimed task now throws (previously silently succeeded). No test or doc flow relied on that; if a downstream flow did, it now fails loudly rather than silently corrupting board state.