### PR TITLE
fix: teammate lifecycle robustness — stall detection, orphan recovery, deadlocks, merge/broadcast accuracy

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -5,6 +5,32 @@ import { findTeamBySession } from "./types"
 
 const TEAM_TOOL_PREFIX = "team_"
 
+/**
+ * Retry-specific payload carried by a `session.status` event when
+ * `status === "retry"`. Mirrors the SDK's `SessionStatus` retry variant.
+ * `action` is optional and free-form (not rate-limit-specific) — see Fix 2
+ * in the retry-observability spec.
+ */
+export interface RetryStatusPayload {
+  attempt: number
+  message: string
+  action?: {
+    reason: string
+    provider: string
+    title: string
+    message: string
+    label: string
+    link?: string
+  }
+  /**
+   * Absolute epoch-ms timestamp of the next retry attempt — NOT a relative
+   * delta. Confirmed against the opencode server/TUI source (session.retry.scheduled
+   * emits `{attempt, at, error}` mapped straight onto `next`, and the built-in
+   * TUI computes remaining seconds as `Math.round((next - Date.now()) / 1000)`).
+   */
+  next: number
+}
+
 /** Result of a session status event — tells the caller what transition happened. */
 export interface StatusTransition {
   memberName: string
@@ -18,12 +44,17 @@ export interface StatusTransition {
  * in SQLite based on the new session status.
  * Ignores events for unknown sessions or archived teams.
  * Returns the transition if one occurred, for toast notifications.
+ *
+ * `retryPayload` is only consulted when `status === "retry"` — it persists
+ * the four additive retry_* columns (Fix 2) without changing `status`/
+ * `execution_status` at all (Fix 1's non-goal: no FSM change).
  */
 export function handleSessionStatusEvent(
   db: Database,
   registry: MemberRegistry,
   sessionId: string,
   status: "idle" | "busy" | "retry",
+  retryPayload?: RetryStatusPayload,
 ): StatusTransition | undefined {
   const entry = registry.getBySession(sessionId)
   if (!entry) return undefined
@@ -72,7 +103,24 @@ export function handleSessionStatusEvent(
       return { memberName: entry.memberName, teamId: entry.teamId, from: "shutdown_requested", to: "busy_while_shutdown" }
     }
   } else if (status === "retry") {
-    // Session is being rate-limited — signal for toast but don't change state
+    // Session is being rate-limited — signal for toast but don't change state.
+    // Persist the retry_* columns so the signal survives past the toast (Fix 2)
+    // — status/execution_status are untouched, and there is no "provider
+    // throttled" language baked in here: the SDK's retry status is generic,
+    // so we surface whatever action.message/status.message actually says.
+    if (retryPayload) {
+      db.run(
+        "UPDATE team_member SET retry_until = ?, retry_attempt = ?, retry_provider = ?, retry_message = ? WHERE team_id = ? AND name = ?",
+        [
+          retryPayload.next,
+          retryPayload.attempt,
+          retryPayload.action?.provider ?? null,
+          retryPayload.action?.message ?? retryPayload.message ?? null,
+          entry.teamId,
+          entry.memberName,
+        ]
+      )
+    }
     return { memberName: entry.memberName, teamId: entry.teamId, from: member.status, to: "retry" }
   }
   return undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,10 @@ const plugin: Plugin = async (input) => {
       if (event.type === "session.status") {
         const { sessionID, status } = event.properties
         const statusType = status.type as "idle" | "busy" | "retry"
-        const transition = handleSessionStatusEvent(db, registry, sessionID, statusType)
+        const retryPayload = statusType === "retry"
+          ? (status as { attempt: number; message: string; action?: { reason: string; provider: string; title: string; message: string; label: string; link?: string }; next: number })
+          : undefined
+        const transition = handleSessionStatusEvent(db, registry, sessionID, statusType, retryPayload)
 
         // Fire toast notifications for meaningful transitions
         if (transition) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import path from "node:path"
 import { mkdirSync } from "node:fs"
 import { createDb, getDbPath } from "./db"
 import { wrapThrowingClient } from "./client"
-import { recoverStaleMembers, recoverUndeliveredMessages, recoverOrphanedWorktrees, recoverOrphanedBranches, rehydrateRegistry } from "./recovery"
+import { recoverStaleMembers, recoverUndeliveredMessages, recoverOrphanedWorktrees, recoverOrphanedBranches, recoverOrphanedTeams, rehydrateRegistry } from "./recovery"
 import { MemberRegistry, DescendantTracker, PendingPurgeApprovals } from "./state"
 import { isWorktreeInstance } from "./util"
 import { handleSessionStatusEvent, handleSessionCreatedEvent, checkToolIsolation, shouldNudgeIdleMember, handleSessionErrorEvent } from "./hooks"
@@ -72,13 +72,35 @@ const plugin: Plugin = async (input) => {
   const rawClient = new OpencodeClient({ client: pluginTransport })
   initLog(rawClient)
   const client = wrapThrowingClient(rawClient)
-  const deps: ToolDeps = { db, registry, tracker, purgeApprovals, client, directory: input.directory, config }
+  const deps: ToolDeps = { db, registry, tracker, purgeApprovals, client, directory: input.directory, config, progressTracker }
 
   // Recovery only runs for the main project instance — NOT for teammate worktree instances.
   // Worktree instances are created during session.create. Running recovery there makes HTTP
   // calls back to the server, which deadlocks because the server is still handling session.create.
   if (!isWorktreeInstance(input.directory)) {
     log("init:recovery:start (main instance)")
+
+    // Reconciles teams whose lead session was deleted externally (not via
+    // team_cleanup) -- otherwise they stay 'active' forever, blocking
+    // team_create/team_cleanup for that name across restarts. See
+    // recoverOrphanedTeams' own doc comment for the full mechanism.
+    //
+    // Fire-and-forget, NOT awaited: isSessionAlive() calls client.session.get(),
+    // an HTTP call back to this same server. Awaiting it synchronously here --
+    // before the server has finished bootstrapping -- reproduced a real,
+    // confirmed deadlock (server never responds to ANY request, including
+    // unrelated ones like /config) when a stale team from a prior run exists
+    // for this project. Matches the existing pattern for the other three
+    // non-critical recovery passes below, and the documented reason
+    // recoverStaleMembers is skipped entirely for worktree instances two lines
+    // up ("makes HTTP calls back to the server, which deadlocks"). isSessionAlive
+    // itself also carries a bounded timeout as defense in depth.
+    recoverOrphanedTeams(db, client, input.directory, registry).then((result) => {
+      if (result.archived > 0) log(`init:recovery:orphaned-teams-archived=${result.archived}`)
+    }).catch((err) => {
+      log(`init:recover-orphaned-teams:failed err=${err instanceof Error ? err.message : String(err)}`)
+    })
+
     const recovery = await recoverStaleMembers(db, client, input.directory)
     if (recovery.interrupted > 0) {
       log(`init:recovery:interrupted=${recovery.interrupted}`)
@@ -196,6 +218,12 @@ const plugin: Plugin = async (input) => {
             }
           } else if (transition.to === "error") {
             notifyTeamEvent(client, "error", { memberName: transition.memberName })
+          } else if (transition.to === "busy") {
+            // Fresh busy period (ready/error -> busy) — give checkStalled a baseline
+            // that doesn't depend on a step-finish event having landed yet. Without
+            // this, a member whose first action is one long-running tool call is
+            // never detected as stalled until that call itself returns.
+            progressTracker.recordBusyStart(sessionID)
           } else if (transition.to === "retry") {
             // Teammate is being rate-limited — notify user
             try {
@@ -421,6 +449,7 @@ const plugin: Plugin = async (input) => {
           text: tool.schema.string().describe("Message content (max 10KB)"),
           approve: tool.schema.boolean().optional().describe("Approve a teammate's plan (only when recipient has plan_approval='pending')"),
           reject: tool.schema.string().optional().describe("Reject a teammate's plan with reason (only when recipient has plan_approval='pending')"),
+          force: tool.schema.boolean().optional().describe("Lead only. Re-activate a teammate who already reported task completion (normally their session won't be woken again). Use for legitimate follow-on work — e.g. the next round of a multi-round debate — not for courtesy replies."),
         },
         async execute(args, ctx) {
           const result = await executeTeamMessage(deps, args, ctx.sessionID)
@@ -440,8 +469,13 @@ const plugin: Plugin = async (input) => {
         },
         async execute(args, ctx) {
           const result = await executeTeamBroadcast(deps, args, ctx.sessionID)
-          // Track broadcast activity for stall detection
+          // Track broadcast activity for stall detection AND chatty detection --
+          // a broadcast reaches every teammate at once, arguably the most
+          // "chatty" action possible, and was previously invisible to
+          // checkChatty()'s peer-message rate limit (recordPeerMessage was never
+          // called here, only recordMessage).
           progressTracker.recordMessage(ctx.sessionID)
+          progressTracker.recordPeerMessage(ctx.sessionID)
           ctx.metadata({ title: "Broadcast to team" })
           return result
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -214,7 +214,9 @@ const plugin: Plugin = async (input) => {
               client.session.promptAsync({
                 sessionID,
                 parts: [{ type: "text", text: "[System]: You completed your work but did not report results. Send your findings to the lead via team_message now." }],
-              }).catch(() => { /* best effort */ })
+              }).catch((err) => {
+                log(`nudge:idle-without-report:failed name=${transition.memberName} team=${transition.teamId} err=${err instanceof Error ? err.message : String(err)}`)
+              })
             }
           } else if (transition.to === "error") {
             notifyTeamEvent(client, "error", { memberName: transition.memberName })

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -12,6 +12,7 @@ export class ProgressTracker {
   private steps = new Map<string, StepRecord[]>()
   private lastMessageAt = new Map<string, number>()
   private lastTaskAt = new Map<string, number>()
+  private busySince = new Map<string, number>()
   private peerMessages = new Map<string, number[]>()
   private reported = new Set<string>()
   private chattyReported = new Set<string>()
@@ -83,15 +84,26 @@ export class ProgressTracker {
     return recent.every(r => r.outputTokens < threshold)
   }
 
-  /** Time-based stall: no message or task completion within `thresholdMs` of now. */
+  /**
+   * Record that this member transitioned to busy. Gives isTimeStalled a baseline
+   * independent of step records, so a member whose first (or only) action is one
+   * long-running tool call is still subject to time-based stall detection before
+   * any step-finish event has landed.
+   */
+  recordBusyStart(sessionId: string): void {
+    this.busySince.set(sessionId, Date.now())
+  }
+
+  /** Time-based stall: no message, task completion, step, or busy-transition within `thresholdMs` of now. */
   isTimeStalled(sessionId: string, thresholdMs: number): boolean {
     const records = this.steps.get(sessionId)
-    if (!records || records.length === 0) return false
-
     const msgAt = this.lastMessageAt.get(sessionId) ?? 0
     const taskAt = this.lastTaskAt.get(sessionId) ?? 0
-    const lastStep = records[records.length - 1]?.timestamp ?? 0
-    const baseline = Math.max(msgAt, taskAt, lastStep)
+    const lastStepAt = records && records.length > 0 ? records[records.length - 1]!.timestamp : 0
+    const busySince = this.busySince.get(sessionId) ?? 0
+
+    const baseline = Math.max(msgAt, taskAt, lastStepAt, busySince)
+    if (baseline === 0) return false // no activity or busy signal recorded at all yet
 
     return Date.now() - baseline >= thresholdMs
   }
@@ -116,6 +128,7 @@ export class ProgressTracker {
     this.steps.delete(sessionId)
     this.lastMessageAt.delete(sessionId)
     this.lastTaskAt.delete(sessionId)
+    this.busySince.delete(sessionId)
     this.peerMessages.delete(sessionId)
     this.reported.delete(sessionId)
     this.chattyReported.delete(sessionId)

--- a/src/recovery.ts
+++ b/src/recovery.ts
@@ -7,13 +7,97 @@ import { log } from "./log"
 import { runCommand } from "./process"
 
 /**
+ * Whether a session still exists in OpenCode. `client.session.get` throws for a
+ * deleted/unknown session rather than returning empty data -- see dashboard.ts's
+ * existing best-effort usage of the same call.
+ *
+ * Bounded by a timeout: a `session.get` call made from within this plugin's own
+ * init sequence, before the server has finished bootstrapping, can hang the
+ * request indefinitely rather than resolve or reject -- the same class of
+ * self-referential-HTTP-call deadlock team-spawn.ts's own `withTimeout` exists
+ * to guard against for `worktree.create`/`session.create` ("makes HTTP calls
+ * back to the server, which deadlocks because the server is still handling
+ * session.create"). On timeout, treat liveness as UNKNOWN (return true, i.e.
+ * "assume alive, don't archive") rather than assuming dead -- a false negative
+ * here just means the orphan isn't reconciled this pass; a false positive means
+ * archiving a team that might still be genuinely active.
+ */
+export async function isSessionAlive(client: PluginClient, sessionId: string, timeoutMs = 5000): Promise<boolean> {
+  try {
+    await Promise.race([
+      client.session.get({ sessionID: sessionId }),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("isSessionAlive timed out")), timeoutMs)),
+    ])
+    return true
+  } catch (err) {
+    if (err instanceof Error && err.message === "isSessionAlive timed out") {
+      log(`recovery:team:liveness-check-timeout session=${sessionId}`)
+      return true
+    }
+    return false
+  }
+}
+
+/**
+ * Reconcile 'active' teams whose lead session no longer exists in OpenCode --
+ * e.g. the user deleted the session via OpenCode's own session UI/API, not via
+ * team_cleanup. Ensemble's own bookkeeping has no way to learn about that on its
+ * own: nothing tells it the session is gone, so the team row stays 'active'
+ * forever, blocking team_create ("already exists") and team_cleanup's purge path
+ * ("cannot purge active team" -- purge only operates on archived teams) for that
+ * name indefinitely. A team with no live lead session is unrecoverable through
+ * any legitimate path (there is no "reassign lead" tool), so archiving it directly
+ * is safe regardless of member state -- the existing recoverOrphanedWorktrees/
+ * recoverOrphanedBranches passes then naturally sweep up its resources on the same
+ * recovery cycle, since those already scope to archived teams with no active
+ * members.
+ *
+ * Scoped by cwd the same way recoverStaleMembers is, to avoid reconciling other
+ * projects' teams when multiple projects share one DB.
+ */
+export async function recoverOrphanedTeams(
+  db: Database,
+  client: PluginClient,
+  cwd?: string,
+  registry?: MemberRegistry,
+): Promise<{ archived: number }> {
+  const active = db.query(
+    `SELECT id, lead_session_id FROM team
+     WHERE status = 'active' AND (? IS NULL OR project_id = ? OR project_id = 'default')`
+  ).all(cwd ?? null, cwd ?? null) as Array<{ id: string; lead_session_id: string }>
+
+  let archived = 0
+  for (const team of active) {
+    if (await isSessionAlive(client, team.lead_session_id)) continue
+
+    db.run("UPDATE team SET status = 'archived', time_updated = ? WHERE id = ?", [Date.now(), team.id])
+    registry?.unregisterTeam(team.id)
+    archived++
+    log(`recovery:team:orphaned team_id=${team.id} lead_session=${team.lead_session_id}`)
+  }
+
+  return { archived }
+}
+
+/**
  * Scan for team members stuck in 'busy' status (stale from a crash)
  * and mark them as 'error' with execution_status 'idle'.
  * Preserves worktree branches before aborting orphaned sessions.
  * Only processes members in active teams.
  * Returns the count of interrupted members.
+ *
+ * `abortTimeoutMs` bounds each `client.session.abort()` call -- the same
+ * self-referential-HTTP-call-back-to-this-server shape as
+ * `isSessionAlive()`'s `client.session.get()` (see that function's doc
+ * comment for the full deadlock mechanism, confirmed live 2026-08-17). This
+ * function is awaited synchronously in plugin init (unlike
+ * `recoverOrphanedTeams`, which is fire-and-forget) because
+ * `rehydrateRegistry` depends on it completing first, so a bounded timeout on
+ * the network call -- not restructuring the await -- is the fix here: the
+ * DB-only work (marking members 'error') always completes and is reflected in
+ * the returned count regardless of whether any individual abort call settles.
  */
-export async function recoverStaleMembers(db: Database, client?: PluginClient, cwd?: string): Promise<{ interrupted: number }> {
+export async function recoverStaleMembers(db: Database, client?: PluginClient, cwd?: string, abortTimeoutMs = 5000): Promise<{ interrupted: number }> {
   // Find stale members with branch info so we can preserve before aborting
   const stale = db.query(
     `SELECT tm.session_id, tm.worktree_branch, tm.name, tm.team_id, t.name as team_name, p.name as project_name
@@ -45,8 +129,16 @@ export async function recoverStaleMembers(db: Database, client?: PluginClient, c
         }
       }
       try {
-        await client.session.abort({ sessionID: member.session_id })
-      } catch { /* best effort */ }
+        await Promise.race([
+          client.session.abort({ sessionID: member.session_id }),
+          new Promise<never>((_, reject) => setTimeout(() => reject(new Error("session.abort timed out")), abortTimeoutMs)),
+        ])
+      } catch (err) {
+        if (err instanceof Error && err.message === "session.abort timed out") {
+          log(`recovery:stale-members:abort-timeout session=${member.session_id}`)
+        }
+        /* best effort */
+      }
     }
   }
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -186,6 +186,13 @@ export const MIGRATIONS: string[] = [
    CREATE INDEX IF NOT EXISTS team_message_undelivered_idx ON team_message(team_id, delivered) WHERE delivered = 0;
    CREATE INDEX IF NOT EXISTS team_message_unread_idx ON team_message(team_id, read) WHERE read = 0;
    PRAGMA foreign_keys=ON;`,
+  // Migration 9: Add last_nudged_at to team_member — additive-only display-staleness
+  // signal for the watchdog's soft stall-nudge path. Deliberately NOT a new status
+  // enum value (see checkStalled() in watchdog.ts for the rationale): a 6th CHECK
+  // constraint literal would require a table-rebuild migration and touch every
+  // consumer that switches on the 5 known status strings. This column is additive —
+  // existing consumers that don't know about it simply don't render it.
+  `ALTER TABLE team_member ADD COLUMN last_nudged_at INTEGER;`,
 ]
 
 /**

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -193,6 +193,17 @@ export const MIGRATIONS: string[] = [
   // consumer that switches on the 5 known status strings. This column is additive —
   // existing consumers that don't know about it simply don't render it.
   `ALTER TABLE team_member ADD COLUMN last_nudged_at INTEGER;`,
+  // Migration 10: Add retry_* columns to team_member — additive-only provider-retry
+  // display signal (see hooks.ts's "retry" branch). Same non-negotiable as Migration
+  // 9: no 6th status/execution_status literal, no table rebuild. retry_until is a
+  // TTL, not a stored enum — "currently retrying" is derived at read time
+  // (retry_until > Date.now()), so there is no explicit clear-write anywhere in this
+  // fix; it simply becomes stale and gets superseded by real activity or by time
+  // elapsing.
+  `ALTER TABLE team_member ADD COLUMN retry_until INTEGER;
+   ALTER TABLE team_member ADD COLUMN retry_attempt INTEGER;
+   ALTER TABLE team_member ADD COLUMN retry_provider TEXT;
+   ALTER TABLE team_member ADD COLUMN retry_message TEXT;`,
 ]
 
 /**

--- a/src/tools/team-create.ts
+++ b/src/tools/team-create.ts
@@ -1,6 +1,7 @@
 import type { ToolDeps } from "../types"
 import { generateId, generateProjectName, validateProjectName, validateTeamName } from "../util"
 import { findTeamBySession } from "../types"
+import { isSessionAlive } from "../recovery"
 
 /**
  * Execute the team_create tool. Creates a new team with the caller as lead.
@@ -19,8 +20,20 @@ export async function executeTeamCreate(
 
   // Check if team name already exists
   const projectId = deps.directory
-  const existing = deps.db.query("SELECT id FROM team WHERE name = ? AND project_id = ? AND status = 'active'").get(args.name, projectId)
-  if (existing) throw new Error(`Team "${args.name}" already exists`)
+  const existing = deps.db.query("SELECT id, lead_session_id FROM team WHERE name = ? AND project_id = ? AND status = 'active'")
+    .get(args.name, projectId) as { id: string; lead_session_id: string } | undefined
+  if (existing) {
+    // The existing team's lead session may have been deleted externally (via
+    // OpenCode's own session UI/API, not team_cleanup) rather than genuinely
+    // still being in use. Reconcile on demand rather than block this call on a
+    // team nobody can ever be lead of again -- don't wait for the next plugin
+    // restart's periodic recoverOrphanedTeams pass to notice.
+    if (await isSessionAlive(deps.client, existing.lead_session_id)) {
+      throw new Error(`Team "${args.name}" already exists`)
+    }
+    deps.db.run("UPDATE team SET status = 'archived', time_updated = ? WHERE id = ?", [Date.now(), existing.id])
+    deps.registry.unregisterTeam(existing.id)
+  }
 
   // Check if session already leads a team
   const lead = findTeamBySession(deps.db, deps.registry, sessionId)

--- a/src/tools/team-merge.ts
+++ b/src/tools/team-merge.ts
@@ -1,5 +1,6 @@
 import type { ToolDeps } from "../types"
-import { requireLead } from "./shared"
+import { requireLead, checkWorktreeDirty, countBranchCommits } from "./shared"
+import type { IsDirtyFn, CommitCountFn } from "./shared"
 import { mergeBranch, deleteBranch, getOverlappingFiles } from "./merge-helper"
 import type { MergeBranchFn, DeleteBranchFn, OverlapCheckFn } from "./merge-helper"
 import { log } from "../log"
@@ -15,11 +16,13 @@ export async function executeTeamMerge(
   merge: MergeBranchFn = mergeBranch,
   delBranch: DeleteBranchFn = deleteBranch,
   overlapCheck: OverlapCheckFn = getOverlappingFiles,
+  commitCount: CommitCountFn = countBranchCommits,
+  isDirty: IsDirtyFn = checkWorktreeDirty,
 ): Promise<string> {
   const teamInfo = requireLead(deps, sessionId)
 
-  const member = deps.db.query("SELECT status, worktree_branch FROM team_member WHERE team_id = ? AND name = ?")
-    .get(teamInfo.teamId, args.member) as { status: string; worktree_branch: string | null } | null
+  const member = deps.db.query("SELECT status, worktree_branch, worktree_dir FROM team_member WHERE team_id = ? AND name = ?")
+    .get(teamInfo.teamId, args.member) as { status: string; worktree_branch: string | null; worktree_dir: string | null } | null
   if (!member) throw new Error(`Teammate "${args.member}" not found in team "${teamInfo.teamName}"`)
 
   if (member.status !== "shutdown" && member.status !== "error") {
@@ -32,6 +35,30 @@ export async function executeTeamMerge(
 
   const branch = member.worktree_branch
   log(`merge:start member=${args.member} branch=${branch}`)
+
+  // A branch with zero new commits produces a trivially "successful" no-op squash merge --
+  // there is genuinely nothing to apply. Reporting that as "Merged ... changes" is
+  // misleading: if the teammate's worktree still has uncommitted work, that work was never
+  // captured on the branch at all and is about to be permanently lost the moment the
+  // worktree is removed (e.g. by team_cleanup). Say so plainly instead of a false success,
+  // and don't tear down the branch/worktree while it may be the only copy of the work.
+  // A commit-count check failure returns -1 (unknown) -- never treat that as "nothing to
+  // merge"; fall through to the real merge attempt so a check failure can't silently skip
+  // real work.
+  const commits = await commitCount(branch, deps.directory)
+  if (commits === 0) {
+    const dirty = member.worktree_dir ? await isDirty(member.worktree_dir).catch(() => false) : false
+    if (dirty) {
+      return [
+        `Nothing to merge for "${args.member}" — their branch (${branch}) has no commits.`,
+        `Their worktree still has uncommitted changes that were never captured on the branch.`,
+        `This work will be permanently lost if the worktree is removed (e.g. via team_cleanup).`,
+        member.worktree_dir ? `Worktree: ${member.worktree_dir}` : ``,
+        `Recover manually (copy files out of the worktree) before shutting down/cleaning up, or re-spawn and instruct them to commit their changes before reporting done.`,
+      ].filter(Boolean).join("\n")
+    }
+    return `Nothing to merge for "${args.member}" — their branch (${branch}) has no commits and no uncommitted changes. They made no changes.`
+  }
 
   // Block merge if lead has local changes to files the agent also modified
   try {

--- a/src/tools/team-message.ts
+++ b/src/tools/team-message.ts
@@ -7,13 +7,19 @@ import { log } from "../log"
 /**
  * Execute the team_message tool. Sends a direct message to a teammate or lead.
  * Optionally approves or rejects a teammate's plan (lead only).
+ * Optionally forces delivery to a teammate who already reported completion (lead only) —
+ * see the `force` guard below.
  */
 export async function executeTeamMessage(
   deps: ToolDeps,
-  args: { to: string; text: string; approve?: boolean; reject?: string },
+  args: { to: string; text: string; approve?: boolean; reject?: string; force?: boolean },
   sessionId: string,
 ): Promise<string> {
   const teamInfo = requireTeamMember(deps, sessionId)
+
+  if (args.force && teamInfo.role !== "lead") {
+    throw new Error("Only the lead can force-deliver a message to a completed teammate.")
+  }
 
   const senderName = teamInfo.role === "lead" ? "lead" : (teamInfo.memberName ?? "unknown")
 
@@ -90,9 +96,13 @@ export async function executeTeamMessage(
     return `Message sent to ${args.to}.`
   }
 
-  // Guard: skip promptAsync delivery to teammates who have already reported completion (issue #3)
-  if (hasReportedCompletion(deps.db, teamInfo.teamId, args.to)) {
-    return `Message stored for ${args.to} (teammate has completed their task — message will not wake them).`
+  // Guard: skip promptAsync delivery to teammates who have already reported completion (issue #3),
+  // unless the lead explicitly forces it. Forcing wakes the session; the natural busy transition
+  // (handleSessionStatusEvent) resets the completion flag when the teammate next goes idle, the
+  // same reset that already happens for a normal re-activation — this just gives the lead a way
+  // to trigger it deliberately instead of it being unreachable once the guard is set.
+  if (hasReportedCompletion(deps.db, teamInfo.teamId, args.to) && !args.force) {
+    return `Message stored for ${args.to} (teammate has completed their task — message will not wake them). Pass force:true to re-activate them.`
   }
 
   // For member-to-member messages, fire-and-forget delivery is safe.

--- a/src/tools/team-spawn.ts
+++ b/src/tools/team-spawn.ts
@@ -231,6 +231,12 @@ export async function executeTeamSpawn(
     [teamInfo.teamId, args.name, childSessionId, agent, resolvedModel ?? null, args.prompt, worktreeDir, worktreeBranch, workspaceId, planApproval, now, now]
   )
 
+  // Row is inserted as 'busy' directly -- there is no ready->busy status-event
+  // transition for a fresh spawn, so the watchdog's usual hook point never fires.
+  // Record the baseline here instead, or a member stalled on its first action
+  // is invisible to checkStalled() until its first step-finish event lands.
+  deps.progressTracker.recordBusyStart(childSessionId)
+
   // Register in memory
   deps.registry.register(teamInfo.teamId, args.name, childSessionId)
 

--- a/src/tools/team-status.ts
+++ b/src/tools/team-status.ts
@@ -4,7 +4,27 @@ import { requireTeamMember } from "./shared"
 /** Tracks the last time team_status was called per team ID (epoch ms). */
 export const lastCallTime = new Map<string, number>()
 
+/** Tracks the state marker (see computeStateMarker) observed at the last real read per team. */
+export const lastKnownState = new Map<string, number>()
+
 const RATE_LIMIT_MS = 30_000
+
+/**
+ * Cheap per-team "has anything changed" fingerprint — the max time_updated/time_created
+ * across the three tables team_status reports on. One MAX() query, no hashing: the
+ * throttle only needs to detect "something changed," not what, so this is deliberately
+ * the simplest sufficient version (see Fix 3 in the spec).
+ */
+function computeStateMarker(deps: ToolDeps, teamId: string): number {
+  const row = deps.db.query(
+    `SELECT MAX(x) as marker FROM (
+       SELECT MAX(time_updated) as x FROM team_member WHERE team_id = ?
+       UNION SELECT MAX(time_updated) FROM team_task WHERE team_id = ?
+       UNION SELECT MAX(time_created) FROM team_message WHERE team_id = ?
+     )`
+  ).get(teamId, teamId, teamId) as { marker: number | null } | null
+  return row?.marker ?? 0
+}
 
 /** Format a duration in ms to a human-readable string. */
 export function formatDuration(ms: number): string {
@@ -24,15 +44,19 @@ export async function executeTeamStatus(
 
   const now = Date.now()
   const last = lastCallTime.get(teamInfo.teamId)
-  if (last !== undefined && (now - last) < RATE_LIMIT_MS) {
+  const currentMarker = computeStateMarker(deps, teamInfo.teamId)
+  // The 30s throttle's purpose is preventing hammering, not lying about state — only
+  // short-circuit when nothing has actually changed since the last real read.
+  if (last !== undefined && (now - last) < RATE_LIMIT_MS && lastKnownState.get(teamInfo.teamId) === currentMarker) {
     return "No changes since last check."
   }
   lastCallTime.set(teamInfo.teamId, now)
+  lastKnownState.set(teamInfo.teamId, currentMarker)
 
   const members = deps.db.query(
-    "SELECT name, session_id, agent, status, execution_status, worktree_branch, worktree_dir, plan_approval, time_updated FROM team_member WHERE team_id = ? ORDER BY time_created ASC"
+    "SELECT name, session_id, agent, status, execution_status, worktree_branch, worktree_dir, plan_approval, time_updated, last_nudged_at FROM team_member WHERE team_id = ? ORDER BY time_created ASC"
   ).all(teamInfo.teamId) as Array<{
-    name: string; session_id: string; agent: string; status: string; execution_status: string; worktree_branch: string | null; worktree_dir: string | null; plan_approval: string; time_updated: number
+    name: string; session_id: string; agent: string; status: string; execution_status: string; worktree_branch: string | null; worktree_dir: string | null; plan_approval: string; time_updated: number; last_nudged_at: number | null
   }>
 
   const tasks = deps.db.query(
@@ -52,13 +76,17 @@ export async function executeTeamStatus(
       const duration = formatDuration(now - m.time_updated)
       const branch = m.worktree_branch ? `  branch: ${m.worktree_branch}` : ""
       const plan = m.plan_approval !== "none" ? `, plan: ${m.plan_approval}` : ""
+      // Additive display-staleness annotation (Fix 1) — surfaces a soft stall-nudge
+      // without inventing a new status value. Annotates the existing status, doesn't
+      // replace it.
+      const nudged = m.last_nudged_at ? `, nudged ${formatDuration(now - m.last_nudged_at)} ago` : ""
 
       // Last message time
       const lastMsg = deps.db.query("SELECT MAX(time_created) as last_msg FROM team_message WHERE team_id = ? AND from_name = ?")
         .get(teamInfo.teamId, m.name) as { last_msg: number | null } | null
       const msgInfo = lastMsg?.last_msg ? `last msg: ${formatDuration(now - lastMsg.last_msg)} ago` : "no messages yet"
 
-      lines.push(`  ${m.name}  [${statusIcon} ${duration}, ${msgInfo}${plan}]  agent: ${m.agent}${branch}`)
+      lines.push(`  ${m.name}  [${statusIcon} ${duration}, ${msgInfo}${plan}${nudged}]  agent: ${m.agent}${branch}`)
 
       // Current task
       const task = deps.db.query("SELECT content FROM team_task WHERE team_id = ? AND assignee = ? AND status = 'in_progress' LIMIT 1")

--- a/src/tools/team-status.ts
+++ b/src/tools/team-status.ts
@@ -54,9 +54,10 @@ export async function executeTeamStatus(
   lastKnownState.set(teamInfo.teamId, currentMarker)
 
   const members = deps.db.query(
-    "SELECT name, session_id, agent, status, execution_status, worktree_branch, worktree_dir, plan_approval, time_updated, last_nudged_at FROM team_member WHERE team_id = ? ORDER BY time_created ASC"
+    "SELECT name, session_id, agent, status, execution_status, worktree_branch, worktree_dir, plan_approval, time_updated, last_nudged_at, retry_until, retry_attempt FROM team_member WHERE team_id = ? ORDER BY time_created ASC"
   ).all(teamInfo.teamId) as Array<{
     name: string; session_id: string; agent: string; status: string; execution_status: string; worktree_branch: string | null; worktree_dir: string | null; plan_approval: string; time_updated: number; last_nudged_at: number | null
+    retry_until: number | null; retry_attempt: number | null
   }>
 
   const tasks = deps.db.query(
@@ -80,13 +81,18 @@ export async function executeTeamStatus(
       // without inventing a new status value. Annotates the existing status, doesn't
       // replace it.
       const nudged = m.last_nudged_at ? `, nudged ${formatDuration(now - m.last_nudged_at)} ago` : ""
+      // Additive provider-retry annotation (Fix 4) — derived at read time from the
+      // retry_until TTL (Fix 3), same annotation pattern as `nudged` above. Generic
+      // "retrying" label, no rate-limit-specific wording (Fix 2).
+      const isRetrying = m.retry_until !== null && m.retry_until > now
+      const retrying = isRetrying ? `, retrying (attempt ${m.retry_attempt}, ~${formatDuration(m.retry_until! - now)})` : ""
 
       // Last message time
       const lastMsg = deps.db.query("SELECT MAX(time_created) as last_msg FROM team_message WHERE team_id = ? AND from_name = ?")
         .get(teamInfo.teamId, m.name) as { last_msg: number | null } | null
       const msgInfo = lastMsg?.last_msg ? `last msg: ${formatDuration(now - lastMsg.last_msg)} ago` : "no messages yet"
 
-      lines.push(`  ${m.name}  [${statusIcon} ${duration}, ${msgInfo}${plan}${nudged}]  agent: ${m.agent}${branch}`)
+      lines.push(`  ${m.name}  [${statusIcon} ${duration}, ${msgInfo}${plan}${nudged}${retrying}]  agent: ${m.agent}${branch}`)
 
       // Current task
       const task = deps.db.query("SELECT content FROM team_task WHERE team_id = ? AND assignee = ? AND status = 'in_progress' LIMIT 1")

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { Database } from "./db"
 import type { MemberRegistry, DescendantTracker, PendingPurgeApprovals } from "./state"
 import type { EnsembleConfig } from "./config"
+import type { ProgressTracker } from "./progress"
 
 /**
  * Shared dependencies injected into every tool's execute function.
@@ -17,6 +18,8 @@ export interface ToolDeps {
   directory: string
   /** Plugin configuration. */
   config: Required<EnsembleConfig>
+  /** Stall/activity tracker — shared with the Watchdog. */
+  progressTracker: ProgressTracker
 }
 
 /** A single permission rule for session-level enforcement. */

--- a/src/watchdog.ts
+++ b/src/watchdog.ts
@@ -3,7 +3,7 @@ import type { PluginClient } from "./types"
 import type { MemberRegistry } from "./state"
 import type { ProgressTracker } from "./progress"
 import { preserveBranch, preservedBranchName } from "./tools/merge-helper"
-import { sendMessage } from "./messaging"
+import { sendMessage, hasReportedCompletion } from "./messaging"
 import { log } from "./log"
 
 interface WatchdogOpts {
@@ -112,14 +112,37 @@ export class Watchdog {
 
       if (!tokenStalled && !timeStalled) continue
 
-      this.progressTracker.markReported(member.session_id)
+      // hasReportedCompletion() is the documented invariant every promptAsync delivery
+      // path must honor (see hooks.ts:63). The in-memory isReported() check above only
+      // catches this watchdog's own prior nudges — it doesn't know if the member reported
+      // completion by some other path while still transiently 'busy' in the DB.
+      if (hasReportedCompletion(this.db, member.team_id, member.name)) {
+        log(`watchdog:stall:skip member=${member.name} team=${member.team_id} reason=already-reported-completion`)
+        continue
+      }
+
       const reason = tokenStalled ? "low output tokens" : "no communication"
 
-      // Nudge the teammate directly
+      // Additive display-staleness signal (does not change team_member.status) — lets
+      // the dashboard/team_status annotate "busy, nudged Xs ago" so a soft nudge is
+      // visible without inventing a new status value.
+      this.db.run(
+        "UPDATE team_member SET last_nudged_at = ? WHERE team_id = ? AND name = ?",
+        [Date.now(), member.team_id, member.name]
+      )
+
+      // Nudge the teammate directly. markReported() only fires once delivery is
+      // confirmed — marking it before delivery is known would permanently and silently
+      // orphan the stall state if promptAsync throws (aborted session, invalid ID),
+      // since ProgressTracker.reported is in-memory and only cleared by new activity.
       this.client.session.promptAsync({
         sessionID: member.session_id,
         parts: [{ type: "text", text: "[System]: You appear stalled — no progress detected. Report your current status to the lead via team_message, or wrap up your work." }],
-      }).catch(() => { /* best effort */ })
+      }).then(() => {
+        this.progressTracker!.markReported(member.session_id)
+      }).catch((err) => {
+        log(`watchdog:stall:nudge-failed member=${member.name} team=${member.team_id} session=${member.session_id} err=${err instanceof Error ? err.message : String(err)}`)
+      })
 
       // Notify the lead
       sendMessage(this.db, {
@@ -156,13 +179,21 @@ export class Watchdog {
       if (this.progressTracker.isChattyReported(member.session_id)) continue
       if (!this.progressTracker.isChatty(member.session_id, this.peerMessageLimit, this.peerMessageWindowMs)) continue
 
+      // hasReportedCompletion() guard — same invariant/rationale as checkStalled() above.
+      if (hasReportedCompletion(this.db, member.team_id, member.name)) {
+        log(`watchdog:chatty:skip member=${member.name} team=${member.team_id} reason=already-reported-completion`)
+        continue
+      }
+
       this.progressTracker.markChattyReported(member.session_id)
 
       // Nudge the agent
       this.client.session.promptAsync({
         sessionID: member.session_id,
         parts: [{ type: "text", text: "[System]: You've sent several messages to teammates. Focus on completing your task and send your results to the lead via team_message." }],
-      }).catch(() => { /* best effort */ })
+      }).catch((err) => {
+        log(`watchdog:chatty:nudge-failed member=${member.name} team=${member.team_id} session=${member.session_id} err=${err instanceof Error ? err.message : String(err)}`)
+      })
 
       // Notify the lead
       sendMessage(this.db, {

--- a/test/completion-loop.test.ts
+++ b/test/completion-loop.test.ts
@@ -157,4 +157,36 @@ describe("issue #3: completion loop prevention", () => {
     const promptCalls = deps.client.calls.filter(c => c.method === "session.promptAsync")
     expect(promptCalls).toHaveLength(1)
   })
+
+  test("lead can force-deliver to a completed teammate via force:true", async () => {
+    const { teamId, memberSession } = await spawnAndComplete("force-team", "henry")
+    deps.client.calls.length = 0
+
+    expect(hasReportedCompletion(deps.db, teamId, "henry")).toBe(true)
+
+    // Without force, existing guard behavior still holds (regression check)
+    const blocked = await executeTeamMessage(deps, { to: "henry", text: "round 2 debate prompt" }, leadSession)
+    expect(blocked).toContain("completed")
+    expect(deps.client.calls.filter(c => c.method === "session.promptAsync")).toHaveLength(0)
+
+    // With force:true, delivery proceeds despite the completion flag
+    const forced = await executeTeamMessage(deps, { to: "henry", text: "round 2 debate prompt", force: true }, leadSession)
+    expect(forced).toBe("Message sent to henry.")
+    const promptCalls = deps.client.calls.filter(c => {
+      if (c.method !== "session.promptAsync") return false
+      const args = c.args[0] as { sessionID: string }
+      return args.sessionID === memberSession
+    })
+    expect(promptCalls).toHaveLength(1)
+  })
+
+  test("force:true is rejected when the sender is not the lead", async () => {
+    await spawnAndComplete("force-guard-team", "ivan")
+    await executeTeamSpawn(deps, { name: "jill", agent: "build", prompt: "task", worktree: false }, leadSession)
+    const jillSession = (deps.db.query("SELECT session_id FROM team_member WHERE name = 'jill'").get() as { session_id: string }).session_id
+
+    await expect(
+      executeTeamMessage(deps, { to: "ivan", text: "hey", force: true }, jillSession),
+    ).rejects.toThrow(/lead/i)
+  })
 })

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -59,6 +59,35 @@ describe("schema migrations", () => {
     expect(row.last_nudged_at).toBeNull()
   })
 
+  test("migration 10 adds additive retry_* columns to team_member, all nullable, no CHECK constraint touched", () => {
+    applyMigrations(db)
+    const cols = db.query("PRAGMA table_info(team_member)").all() as Array<{ name: string; notnull: number; dflt_value: unknown }>
+    for (const name of ["retry_until", "retry_attempt", "retry_provider", "retry_message"]) {
+      const col = cols.find(c => c.name === name)
+      expect(col).toBeTruthy()
+      expect(col?.notnull).toBe(0)
+      expect(col?.dflt_value).toBeNull()
+    }
+
+    // The status CHECK constraint must be untouched — still exactly the 5 known literals.
+    const schemaRow = db.query("SELECT sql FROM sqlite_master WHERE type='table' AND name='team_member'").get() as { sql: string }
+    expect(schemaRow.sql).toContain("CHECK(status IN ('ready', 'busy', 'shutdown_requested', 'shutdown', 'error'))")
+
+    // Existing rows get NULL, not some default sentinel.
+    db.run(
+      "INSERT INTO team (id, name, project_id, lead_session_id, status, delegate, time_created, time_updated) VALUES ('t1', 'team', 'default', 'lead', 'active', 0, 0, 0)"
+    )
+    db.run(
+      "INSERT INTO team_member (team_id, name, session_id, agent, time_created, time_updated) VALUES ('t1', 'alice', 's1', 'build', 0, 0)"
+    )
+    const row = db.query("SELECT retry_until, retry_attempt, retry_provider, retry_message FROM team_member WHERE name = 'alice'").get() as
+      { retry_until: number | null; retry_attempt: number | null; retry_provider: string | null; retry_message: string | null }
+    expect(row.retry_until).toBeNull()
+    expect(row.retry_attempt).toBeNull()
+    expect(row.retry_provider).toBeNull()
+    expect(row.retry_message).toBeNull()
+  })
+
   test("creates team_task table", () => {
     applyMigrations(db)
     const row = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='team_task'").get()

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -36,6 +36,29 @@ describe("schema migrations", () => {
     expect(row).toBeTruthy()
   })
 
+  test("migration 9 adds an additive last_nudged_at column to team_member, nullable, no CHECK constraint touched", () => {
+    applyMigrations(db)
+    const cols = db.query("PRAGMA table_info(team_member)").all() as Array<{ name: string; notnull: number; dflt_value: unknown }>
+    const col = cols.find(c => c.name === "last_nudged_at")
+    expect(col).toBeTruthy()
+    expect(col?.notnull).toBe(0)
+    expect(col?.dflt_value).toBeNull()
+
+    // The status CHECK constraint must be untouched — still exactly the 5 known literals.
+    const schemaRow = db.query("SELECT sql FROM sqlite_master WHERE type='table' AND name='team_member'").get() as { sql: string }
+    expect(schemaRow.sql).toContain("CHECK(status IN ('ready', 'busy', 'shutdown_requested', 'shutdown', 'error'))")
+
+    // Existing rows get NULL, not some default sentinel.
+    db.run(
+      "INSERT INTO team (id, name, project_id, lead_session_id, status, delegate, time_created, time_updated) VALUES ('t1', 'team', 'default', 'lead', 'active', 0, 0, 0)"
+    )
+    db.run(
+      "INSERT INTO team_member (team_id, name, session_id, agent, time_created, time_updated) VALUES ('t1', 'alice', 's1', 'build', 0, 0)"
+    )
+    const row = db.query("SELECT last_nudged_at FROM team_member WHERE name = 'alice'").get() as { last_nudged_at: number | null }
+    expect(row.last_nudged_at).toBeNull()
+  })
+
   test("creates team_task table", () => {
     applyMigrations(db)
     const row = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='team_task'").get()

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -4,6 +4,7 @@ import { applyMigrations } from "../src/schema"
 import { MemberRegistry, DescendantTracker, PendingPurgeApprovals } from "../src/state"
 import type { ToolDeps, PluginClient } from "../src/types"
 import { DEFAULT_CONFIG } from "../src/config"
+import { ProgressTracker } from "../src/progress"
 
 /** Create a fresh in-memory DB with migrations applied. */
 export function setupDb(): EnsembleDatabase {
@@ -102,6 +103,7 @@ export function setupDeps(db?: EnsembleDatabase): ToolDeps & { client: ReturnTyp
     client: mockClient(),
     directory: "/tmp/test-project",
     config: { ...DEFAULT_CONFIG },
+    progressTracker: new ProgressTracker(),
   }
 }
 

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -188,6 +188,92 @@ describe("handleSessionStatusEvent", () => {
     expect(row.execution_status).toBe("running")
   })
 
+  test("Fix 2: persists retry_* columns from the retry payload without touching status", () => {
+    insertTeam(db, "t1", "my-team", "lead-sess")
+    insertMember(db, "t1", "alice", "sess-1", "busy", "running")
+    registry.register("t1", "alice", "sess-1")
+
+    const nextAt = Date.now() + 30_000
+    handleSessionStatusEvent(db, registry, "sess-1", "retry", {
+      attempt: 3,
+      message: "upstream error: 429 too many requests",
+      action: {
+        reason: "provider_overloaded",
+        provider: "anthropic",
+        title: "Provider busy",
+        message: "Anthropic is currently overloaded",
+        label: "Retry",
+      },
+      next: nextAt,
+    })
+
+    const row = db.query(
+      "SELECT status, execution_status, retry_until, retry_attempt, retry_provider, retry_message FROM team_member WHERE session_id = ?"
+    ).get("sess-1") as {
+      status: string; execution_status: string
+      retry_until: number | null; retry_attempt: number | null; retry_provider: string | null; retry_message: string | null
+    }
+
+    // Fix 1's non-goal: status/execution_status are completely untouched.
+    expect(row.status).toBe("busy")
+    expect(row.execution_status).toBe("running")
+
+    // Fix 2: the four retry columns get written from the payload.
+    expect(row.retry_until).toBe(nextAt)
+    expect(row.retry_attempt).toBe(3)
+    expect(row.retry_provider).toBe("anthropic")
+    // action.message wins over the generic status.message when present.
+    expect(row.retry_message).toBe("Anthropic is currently overloaded")
+  })
+
+  test("Fix 2: falls back to status.message when action is absent, and never hardcodes throttle language", () => {
+    insertTeam(db, "t1", "my-team", "lead-sess")
+    insertMember(db, "t1", "alice", "sess-1", "busy", "running")
+    registry.register("t1", "alice", "sess-1")
+
+    handleSessionStatusEvent(db, registry, "sess-1", "retry", {
+      attempt: 1,
+      message: "transient network error, retrying",
+      next: Date.now() + 5_000,
+    })
+
+    const row = db.query(
+      "SELECT retry_provider, retry_message FROM team_member WHERE session_id = ?"
+    ).get("sess-1") as { retry_provider: string | null; retry_message: string | null }
+
+    expect(row.retry_provider).toBeNull()
+    expect(row.retry_message).toBe("transient network error, retrying")
+    // Guard against regressions that hardcode rate-limit-specific language —
+    // the persisted message must be exactly what the SDK reported, no relabeling.
+    expect(row.retry_message).not.toMatch(/rate.?limit/i)
+  })
+
+  test("Fix 3: retry_until is a TTL — the derived isRetrying boolean flips false once it elapses, with no clear-write", () => {
+    insertTeam(db, "t1", "my-team", "lead-sess")
+    insertMember(db, "t1", "alice", "sess-1", "busy", "running")
+    registry.register("t1", "alice", "sess-1")
+
+    const nextAt = Date.now() + 50
+    handleSessionStatusEvent(db, registry, "sess-1", "retry", {
+      attempt: 1,
+      message: "retrying",
+      next: nextAt,
+    })
+
+    const before = db.query("SELECT retry_until FROM team_member WHERE session_id = ?").get("sess-1") as { retry_until: number | null }
+    expect(before.retry_until).toBe(nextAt)
+    expect(before.retry_until !== null && before.retry_until > Date.now()).toBe(true)
+
+    // No explicit clear-write happens anywhere — wait for the TTL to actually elapse.
+    Bun.sleepSync(100)
+
+    const after = db.query("SELECT retry_until FROM team_member WHERE session_id = ?").get("sess-1") as { retry_until: number | null }
+    // The stored value itself is untouched (no clear-write)...
+    expect(after.retry_until).toBe(nextAt)
+    // ...but the read-time derived boolean now reads false, purely from time passing.
+    expect(after.retry_until !== null && after.retry_until > Date.now()).toBe(false)
+  })
+
   test("returns StatusTransition on successful idle transition", () => {
     insertTeam(db, "t1", "my-team", "lead-sess")
     insertMember(db, "t1", "alice", "sess-1", "busy", "running")

--- a/test/merge-flow.test.ts
+++ b/test/merge-flow.test.ts
@@ -312,6 +312,114 @@ describe("team_merge", () => {
   })
 })
 
+// ─── Regression: honest reporting when there's nothing to merge ───
+//
+// Bug found via live N=4 concurrency testing (2026-08-17): a teammate that writes a file
+// but never commits leaves its branch with zero new commits. `git merge --squash` against
+// a branch with nothing new is a legitimate no-op that reports success -- team_merge then
+// unconditionally returned "Merged alice's changes... unstaged", which is TRUE in a narrow
+// technical sense but actively misleading: nothing was actually captured. The uncommitted
+// work exists only in the now-abandoned worktree and is permanently lost the moment
+// team_cleanup removes it. team_shutdown and team_cleanup both already warn about this
+// (uncommitted-changes detection existed before this fix) -- the gap was specifically
+// team_merge's own success message papering over a no-op.
+describe("team_merge — honest reporting when nothing to merge", () => {
+  let deps: Deps
+  const lead = "lead-sess"
+
+  beforeEach(() => {
+    deps = setupDeps()
+    spawnFailures.clear()
+  })
+
+  test("reports uncommitted-work-at-risk instead of false success when branch has zero commits and worktree is dirty", async () => {
+    await executeTeamCreate(deps, { name: "no-commit-dirty" }, lead)
+    await executeTeamSpawn(deps, { name: "alice", agent: "build", prompt: "task" }, lead)
+    await executeTeamShutdown(deps, { member: "alice" }, lead, undefined, noopPreserve)
+
+    let mergeCalled = false
+    let deleteCalled = false
+    const trackMerge: MergeBranchFn = async () => { mergeCalled = true; return { ok: true } }
+    const trackDelete: DeleteBranchFn = async () => { deleteCalled = true; return true }
+
+    const result = await executeTeamMerge(
+      deps, { member: "alice" }, lead,
+      trackMerge, trackDelete, noopOverlap,
+      async () => 0,    // commitCount: zero commits on the branch
+      async () => true, // isDirty: worktree has uncommitted changes
+    )
+
+    expect(result).toContain("Nothing to merge")
+    expect(result).toContain("uncommitted")
+    expect(result).not.toContain("Merged alice's changes")
+    // Must not proceed as if the merge succeeded -- no false "merged" claim, and the
+    // branch/worktree must not be torn down while it's the only copy of the work.
+    expect(mergeCalled).toBe(false)
+    expect(deleteCalled).toBe(false)
+
+    const after = deps.db.query("SELECT worktree_branch FROM team_member WHERE name = 'alice'")
+      .get() as { worktree_branch: string | null }
+    expect(after.worktree_branch).not.toBeNull()
+  })
+
+  test("reports plainly that the member made no changes when branch has zero commits and worktree is clean", async () => {
+    await executeTeamCreate(deps, { name: "no-commit-clean" }, lead)
+    await executeTeamSpawn(deps, { name: "alice", agent: "build", prompt: "task" }, lead)
+    await executeTeamShutdown(deps, { member: "alice" }, lead, undefined, noopPreserve)
+
+    const result = await executeTeamMerge(
+      deps, { member: "alice" }, lead,
+      noopMerge, noopDelete, noopOverlap,
+      async () => 0,     // commitCount: zero commits
+      async () => false, // isDirty: nothing uncommitted either
+    )
+
+    expect(result).toContain("Nothing to merge")
+    expect(result).toContain("no changes")
+    expect(result).not.toContain("Merged alice's changes")
+  })
+
+  test("still merges normally when the branch has real commits", async () => {
+    await executeTeamCreate(deps, { name: "has-commits" }, lead)
+    await executeTeamSpawn(deps, { name: "alice", agent: "build", prompt: "task" }, lead)
+    await executeTeamShutdown(deps, { member: "alice" }, lead, undefined, noopPreserve)
+
+    let mergeCalled = false
+    const trackMerge: MergeBranchFn = async () => { mergeCalled = true; return { ok: true } }
+
+    const result = await executeTeamMerge(
+      deps, { member: "alice" }, lead,
+      trackMerge, noopDelete, noopOverlap,
+      async () => 1,     // commitCount: one real commit
+      async () => false,
+    )
+
+    expect(mergeCalled).toBe(true)
+    expect(result).toContain("Merged alice's changes")
+  })
+
+  test("falls through to the normal merge path when commit count cannot be determined", async () => {
+    await executeTeamCreate(deps, { name: "commit-count-unknown" }, lead)
+    await executeTeamSpawn(deps, { name: "alice", agent: "build", prompt: "task" }, lead)
+    await executeTeamShutdown(deps, { member: "alice" }, lead, undefined, noopPreserve)
+
+    let mergeCalled = false
+    const trackMerge: MergeBranchFn = async () => { mergeCalled = true; return { ok: true } }
+
+    // countBranchCommits returns -1 on failure (git error) -- must not be treated as "zero
+    // commits, nothing to merge". An unknown count should never silently skip a real merge.
+    const result = await executeTeamMerge(
+      deps, { member: "alice" }, lead,
+      trackMerge, noopDelete, noopOverlap,
+      async () => -1,
+      async () => false,
+    )
+
+    expect(mergeCalled).toBe(true)
+    expect(result).toContain("Merged alice's changes")
+  })
+})
+
 // ─── Cleanup safety net ───
 
 describe("cleanup safety net for unmerged branches", () => {

--- a/test/progress.test.ts
+++ b/test/progress.test.ts
@@ -66,6 +66,41 @@ describe("ProgressTracker", () => {
     expect(pt.isTimeStalled("s1", 0)).toBe(true)
   })
 
+  // --- Busy-transition baseline (regression: first-action stall detection gap) ---
+  // isTimeStalled previously bailed out with `false` whenever a session had zero
+  // recorded steps, regardless of how long it had been busy. A teammate whose
+  // entire task is one long-running tool call (e.g. a slow build, sleep, or test
+  // run as its FIRST action) never accumulates a step record until that call
+  // returns — meaning the "sane" nudge+notify stall path never fired for exactly
+  // this pattern, even well past stallThresholdMs. recordBusyStart() gives
+  // isTimeStalled a baseline independent of step records.
+
+  test("isTimeStalled returns true for a busy member with zero step records", () => {
+    const pt = new ProgressTracker()
+    pt.recordBusyStart("s1")
+    expect(pt.isTimeStalled("s1", 0)).toBe(true)
+  })
+
+  test("isTimeStalled still returns false with no busy signal and no steps", () => {
+    const pt = new ProgressTracker()
+    expect(pt.isTimeStalled("s1", 0)).toBe(false)
+  })
+
+  test("isTimeStalled prefers a later step timestamp over an earlier busy-start", () => {
+    const pt = new ProgressTracker()
+    pt.recordBusyStart("s1")
+    pt.recordStep("s1", 100) // more recent activity signal than busy-start
+    pt.recordMessage("s1") // clears nothing relevant; just the most recent signal
+    expect(pt.isTimeStalled("s1", 180_000)).toBe(false)
+  })
+
+  test("remove cleans up busySince state", () => {
+    const pt = new ProgressTracker()
+    pt.recordBusyStart("s1")
+    pt.remove("s1")
+    expect(pt.isTimeStalled("s1", 0)).toBe(false)
+  })
+
   test("recordMessage clears stall report", () => {
     const pt = new ProgressTracker()
     pt.markReported("s1")

--- a/test/recovery.test.ts
+++ b/test/recovery.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import { applyMigrations } from "../src/schema"
-import { recoverStaleMembers, recoverUndeliveredMessages, rehydrateRegistry } from "../src/recovery"
+import { recoverStaleMembers, recoverUndeliveredMessages, rehydrateRegistry, recoverOrphanedTeams, isSessionAlive } from "../src/recovery"
 import type { PluginClient } from "../src/types"
 import { MemberRegistry } from "../src/state"
 import { sendMessage, broadcastMessage } from "../src/messaging"
@@ -72,6 +72,120 @@ function mockClient(): PluginClient & { calls: Array<{ method: string; args: unk
   }
 }
 
+describe("isSessionAlive", () => {
+  let client: ReturnType<typeof mockClient>
+
+  beforeEach(() => {
+    client = mockClient()
+  })
+
+  test("returns true when session.get resolves", async () => {
+    client.session.get = async () => ({ data: {} })
+    expect(await isSessionAlive(client, "sess-1", 50)).toBe(true)
+  })
+
+  test("returns false when session.get throws", async () => {
+    client.session.get = async () => { throw new Error("session not found") }
+    expect(await isSessionAlive(client, "sess-1", 50)).toBe(false)
+  })
+
+  // Regression: a session.get() call made from within this plugin's own init
+  // sequence, before the server has finished bootstrapping, was confirmed to
+  // hang indefinitely rather than resolve or reject -- a self-referential
+  // HTTP-call deadlock, the same class team-spawn.ts's withTimeout already
+  // guards against for worktree.create/session.create. Live-reproduced
+  // 2026-08-17: a real server never responded to ANY request (including
+  // unrelated ones) when a stale team from a prior run existed for the
+  // project. isSessionAlive must resolve within its bound regardless of
+  // whether the underlying call ever settles, and must treat "we genuinely
+  // don't know" as alive (don't archive on an inconclusive check) rather than
+  // as dead.
+  test("resolves within the timeout bound instead of hanging when session.get never settles", async () => {
+    client.session.get = () => new Promise(() => { /* never resolves or rejects */ })
+    const start = Date.now()
+    const result = await isSessionAlive(client, "sess-1", 50)
+    expect(Date.now() - start).toBeLessThan(1000)
+    expect(result).toBe(true)
+  })
+})
+
+describe("recoverOrphanedTeams", () => {
+  let db: Database
+  let client: ReturnType<typeof mockClient>
+
+  beforeEach(() => {
+    db = setupDb()
+    client = mockClient()
+  })
+
+  test("archives an active team whose lead session no longer exists", async () => {
+    insertTeam(db, "t1", "dead-team", "dead-lead-sess")
+    client.session.get = async (options) => {
+      if (options.sessionID === "dead-lead-sess") throw new Error("session not found")
+      return { data: {} }
+    }
+
+    const result = await recoverOrphanedTeams(db, client)
+    expect(result.archived).toBe(1)
+
+    const row = db.query("SELECT status FROM team WHERE id = ?").get("t1") as { status: string }
+    expect(row.status).toBe("archived")
+  })
+
+  test("leaves an active team alone when its lead session is genuinely alive", async () => {
+    insertTeam(db, "t1", "live-team", "live-lead-sess")
+    // Default mock client.session.get always resolves.
+
+    const result = await recoverOrphanedTeams(db, client)
+    expect(result.archived).toBe(0)
+
+    const row = db.query("SELECT status FROM team WHERE id = ?").get("t1") as { status: string }
+    expect(row.status).toBe("active")
+  })
+
+  test("does not touch teams already archived", async () => {
+    insertTeam(db, "t1", "old-team", "dead-lead-sess")
+    db.run("UPDATE team SET status = 'archived' WHERE id = ?", ["t1"])
+    client.session.get = async () => { throw new Error("session not found") }
+
+    const result = await recoverOrphanedTeams(db, client)
+    expect(result.archived).toBe(0)
+  })
+
+  test("unregisters an archived team from the in-memory registry", async () => {
+    insertTeam(db, "t1", "dead-team", "dead-lead-sess")
+    insertMember(db, "t1", "alice", "sess-1", "busy", "running")
+    client.session.get = async (options) => {
+      if (options.sessionID === "dead-lead-sess") throw new Error("session not found")
+      return { data: {} }
+    }
+    const registry = new MemberRegistry()
+    registry.register("t1", "alice", "sess-1")
+
+    await recoverOrphanedTeams(db, client, undefined, registry)
+
+    expect(registry.getBySession("sess-1")).toBeUndefined()
+  })
+
+  test("scopes to the given project when cwd is provided", async () => {
+    db.run(
+      "INSERT INTO project (id, name, path, status, time_created, time_updated) VALUES (?, ?, ?, 'active', ?, ?)",
+      ["/tmp/other-project", "other-project", "/tmp/other-project", Date.now(), Date.now()]
+    )
+    db.run(
+      "INSERT INTO team (id, name, project_id, lead_session_id, status, delegate, time_created, time_updated) VALUES (?, ?, ?, ?, 'active', 0, ?, ?)",
+      ["t2", "other-team", "/tmp/other-project", "dead-lead-sess-2", Date.now(), Date.now()]
+    )
+    client.session.get = async () => { throw new Error("session not found") }
+
+    const result = await recoverOrphanedTeams(db, client, "/tmp/other-project")
+    expect(result.archived).toBe(1)
+
+    const row = db.query("SELECT status FROM team WHERE id = ?").get("t2") as { status: string }
+    expect(row.status).toBe("archived")
+  })
+})
+
 describe("recoverStaleMembers", () => {
   let db: Database
   let client: ReturnType<typeof mockClient>
@@ -123,6 +237,35 @@ describe("recoverStaleMembers", () => {
     const bob = db.query("SELECT status FROM team_member WHERE name = ?").get("bob") as Record<string, string>
     expect(alice.status).toBe("error")
     expect(bob.status).toBe("error")
+  })
+
+  // Regression: client.session.abort() is the same self-referential-HTTP-call
+  // shape as isSessionAlive()'s client.session.get() (recoverOrphanedTeams'
+  // deadlock, fixed 2026-08-17) -- a call back to this same server, made
+  // synchronously from within plugin init before the server has finished
+  // bootstrapping. recoverStaleMembers is awaited synchronously in index.ts
+  // (unlike recoverOrphanedTeams, which is now fire-and-forget) specifically
+  // because rehydrateRegistry depends on it completing first -- so the fix
+  // here is a bounded timeout on the abort call itself, not fire-and-forget.
+  // Confirmed via source review this is a live latent bug, not exercised by
+  // any test data so far only because it requires a genuinely 'busy' member
+  // at restart time, a query-filter coincidence rather than a structural
+  // guard against the underlying deadlock class.
+  test("does not hang forever if session.abort never settles", async () => {
+    insertTeam(db, "t1", "my-team", "lead-sess")
+    insertMember(db, "t1", "alice", "sess-1", "busy", "running")
+    client.session.abort = () => new Promise(() => { /* never resolves or rejects */ })
+
+    const start = Date.now()
+    const result = await recoverStaleMembers(db, client, undefined, 50)
+    expect(Date.now() - start).toBeLessThan(1000)
+
+    // The DB-only work (marking busy members as error) must still have
+    // completed and be reflected in the returned count, independent of
+    // whether the network-side abort ever settles.
+    expect(result.interrupted).toBe(1)
+    const alice = db.query("SELECT status FROM team_member WHERE name = ?").get("alice") as Record<string, string>
+    expect(alice.status).toBe("error")
   })
 
   test("does not touch non-busy members", async () => {

--- a/test/tools/team-create.test.ts
+++ b/test/tools/team-create.test.ts
@@ -45,6 +45,36 @@ describe("team_create", () => {
       .rejects.toThrow("already exists")
   })
 
+  test("reclaims a team name whose lead session no longer exists (orphan reconciliation)", async () => {
+    await executeTeamCreate(deps, { name: "my-team" }, "dead-lead-sess")
+    // Simulate the lead session having been deleted externally (e.g. via OpenCode's
+    // own session UI, not through team_cleanup) -- client.session.get throws for it.
+    const originalGet = deps.client.session.get.bind(deps.client.session)
+    deps.client.session.get = async (options) => {
+      if (options.sessionID === "dead-lead-sess") throw new Error("session not found")
+      return originalGet(options)
+    }
+
+    // A brand new session should be able to reclaim the name instead of hitting
+    // "already exists" against a team nobody can ever be lead of again.
+    const result = await executeTeamCreate(deps, { name: "my-team" }, "new-lead-sess")
+    expect(result).toContain("created")
+
+    const rows = deps.db.query("SELECT lead_session_id, status FROM team WHERE name = ? ORDER BY time_created")
+      .all("my-team") as Array<{ lead_session_id: string; status: string }>
+    expect(rows).toHaveLength(2)
+    expect(rows[0]!.lead_session_id).toBe("dead-lead-sess")
+    expect(rows[0]!.status).toBe("archived")
+    expect(rows[1]!.lead_session_id).toBe("new-lead-sess")
+    expect(rows[1]!.status).toBe("active")
+  })
+
+  test("still rejects duplicate name when the existing lead session is genuinely alive", async () => {
+    await executeTeamCreate(deps, { name: "my-team" }, "lead-sess")
+    // Default mock client.session.get always resolves -- lead-sess reads as alive.
+    await expect(executeTeamCreate(deps, { name: "my-team" }, "other-sess")).rejects.toThrow("already exists")
+  })
+
   test("allows same active team name in different projects", async () => {
     await executeTeamCreate(deps, { name: "my-team" }, "lead-sess")
 

--- a/test/tools/team-spawn.test.ts
+++ b/test/tools/team-spawn.test.ts
@@ -70,6 +70,22 @@ describe("team_spawn", () => {
     expect(row.agent).toBe("build")
   })
 
+  test("records a busy-start baseline on spawn (regression: fresh member inserted directly as busy, never fires a ready->busy transition event)", async () => {
+    const result = await executeTeamSpawn(deps, {
+      name: "alice",
+      agent: "build",
+      prompt: "Fix the tests",
+    }, "lead-sess")
+    expect(result).toContain("spawned")
+
+    const row = deps.db.query("SELECT session_id FROM team_member WHERE name = ?").get("alice") as { session_id: string }
+    // team-spawn.ts inserts the row with status='busy' directly -- there is no
+    // status-event transition for the watchdog to hook. isTimeStalled must still
+    // see a baseline from the moment of spawn, or a teammate stalled on its very
+    // first action (the exact pattern this checklist item tests) is invisible.
+    expect(deps.progressTracker.isTimeStalled(row.session_id, 0)).toBe(true)
+  })
+
   test("rejects if caller is not the lead", async () => {
     insertMember(deps.db, "t1", "bob", "bob-sess")
     deps.registry.register("t1", "bob", "bob-sess")

--- a/test/tools/team-status.test.ts
+++ b/test/tools/team-status.test.ts
@@ -248,4 +248,39 @@ describe("team_status", () => {
     const result = await executeTeamStatus(deps, "lead-sess")
     expect(result).not.toContain("nudged")
   })
+
+  test("Fix 4: annotates a retrying member's existing status with attempt/remaining time, generically labeled", async () => {
+    insertMember(deps.db, "t1", "alice", "sess-alice", "busy", "running")
+    deps.registry.register("t1", "alice", "sess-alice")
+    deps.db.run(
+      "UPDATE team_member SET retry_until = ?, retry_attempt = ? WHERE team_id = ? AND name = ?",
+      [Date.now() + 45_000, 2, "t1", "alice"]
+    )
+
+    const result = await executeTeamStatus(deps, "lead-sess")
+    expect(result).toContain("working") // status label unchanged, not replaced
+    expect(result).toContain("retrying (attempt 2")
+    // Generic label only — never rate-limit-specific wording (Fix 2).
+    expect(result).not.toMatch(/rate.?limit/i)
+  })
+
+  test("Fix 4/Fix 3: does not annotate a member once retry_until has elapsed (derived TTL, no clear-write)", async () => {
+    insertMember(deps.db, "t1", "alice", "sess-alice", "busy", "running")
+    deps.registry.register("t1", "alice", "sess-alice")
+    deps.db.run(
+      "UPDATE team_member SET retry_until = ?, retry_attempt = ? WHERE team_id = ? AND name = ?",
+      [Date.now() - 5_000, 1, "t1", "alice"]
+    )
+
+    const result = await executeTeamStatus(deps, "lead-sess")
+    expect(result).not.toContain("retrying")
+  })
+
+  test("Fix 4: does not annotate a member who has never retried", async () => {
+    insertMember(deps.db, "t1", "alice", "sess-alice", "busy", "running")
+    deps.registry.register("t1", "alice", "sess-alice")
+
+    const result = await executeTeamStatus(deps, "lead-sess")
+    expect(result).not.toContain("retrying")
+  })
 })

--- a/test/tools/team-status.test.ts
+++ b/test/tools/team-status.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach } from "bun:test"
 import { setupDeps, insertTeam, insertMember } from "../helpers"
-import { executeTeamStatus, lastCallTime } from "../../src/tools/team-status"
+import { executeTeamStatus, lastCallTime, lastKnownState } from "../../src/tools/team-status"
 
 describe("team_status", () => {
   let deps: ReturnType<typeof setupDeps>
@@ -9,6 +9,7 @@ describe("team_status", () => {
     deps = setupDeps()
     insertTeam(deps.db, "t1", "my-team", "lead-sess")
     lastCallTime.clear()
+    lastKnownState.clear()
   })
 
   test("shows team with no members", async () => {
@@ -110,6 +111,37 @@ describe("team_status", () => {
     expect(second).toBe("No changes since last check.")
   })
 
+  test("Fix 3: does NOT return the hardcoded 'no changes' string within the 30s throttle window if state actually changed", async () => {
+    insertMember(deps.db, "t1", "alice", "sess-alice", "busy", "running")
+    deps.registry.register("t1", "alice", "sess-alice")
+
+    const first = await executeTeamStatus(deps, "lead-sess")
+    expect(first).toContain("alice")
+
+    // Real state change inside the 30s throttle window — a new teammate spawned.
+    insertMember(deps.db, "t1", "bob", "sess-bob", "busy", "running")
+    deps.registry.register("t1", "bob", "sess-bob")
+    // Force a distinct marker in case both inserts land in the same millisecond.
+    deps.db.run("UPDATE team_member SET time_updated = ? WHERE team_id = ? AND name = ?", [Date.now() + 1000, "t1", "bob"])
+
+    const second = await executeTeamStatus(deps, "lead-sess")
+    expect(second).not.toBe("No changes since last check.")
+    expect(second).toContain("bob")
+  })
+
+  test("Fix 3: still throttles to the hardcoded string when nothing has actually changed", async () => {
+    insertMember(deps.db, "t1", "alice", "sess-alice", "busy", "running")
+    deps.registry.register("t1", "alice", "sess-alice")
+
+    const first = await executeTeamStatus(deps, "lead-sess")
+    expect(first).toContain("alice")
+
+    // No DB mutation between calls — the 30s throttle's original purpose (don't
+    // hammer) should still be preserved when there's genuinely nothing new.
+    const second = await executeTeamStatus(deps, "lead-sess")
+    expect(second).toBe("No changes since last check.")
+  })
+
   test("returns normal status after 30s (manipulate lastCallTime)", async () => {
     insertMember(deps.db, "t1", "alice", "sess-alice", "busy", "running")
     deps.registry.register("t1", "alice", "sess-alice")
@@ -197,5 +229,23 @@ describe("team_status", () => {
 
     const result = await executeTeamStatus(deps, "lead-sess")
     expect(result).toContain("2 total")
+  })
+
+  test("Fix 1: annotates a nudged member's existing status rather than replacing it", async () => {
+    insertMember(deps.db, "t1", "alice", "sess-alice", "busy", "running")
+    deps.registry.register("t1", "alice", "sess-alice")
+    deps.db.run("UPDATE team_member SET last_nudged_at = ? WHERE team_id = ? AND name = ?", [Date.now() - 47_000, "t1", "alice"])
+
+    const result = await executeTeamStatus(deps, "lead-sess")
+    expect(result).toContain("working") // status label unchanged
+    expect(result).toContain("nudged 47s ago")
+  })
+
+  test("Fix 1: does not annotate a member who has never been nudged", async () => {
+    insertMember(deps.db, "t1", "alice", "sess-alice", "busy", "running")
+    deps.registry.register("t1", "alice", "sess-alice")
+
+    const result = await executeTeamStatus(deps, "lead-sess")
+    expect(result).not.toContain("nudged")
   })
 })

--- a/test/watchdog.test.ts
+++ b/test/watchdog.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test"
 import { setupDeps, insertTeam, insertMember } from "./helpers"
 import { Watchdog } from "../src/watchdog"
+import { ProgressTracker } from "../src/progress"
 
 describe("Watchdog", () => {
   let deps: ReturnType<typeof setupDeps>
@@ -212,5 +213,154 @@ describe("Watchdog", () => {
       const row = deps.db.query("SELECT worktree_dir FROM team_member WHERE name = 'alice'").get() as Record<string, unknown>
       expect(row.worktree_dir).toBe("/tmp/wt-alice")
     })
+  })
+})
+
+describe("Watchdog.checkStalled — last_nudged_at, deferred markReported, completion guard", () => {
+  let deps: ReturnType<typeof setupDeps>
+  let pt: ProgressTracker
+
+  beforeEach(() => {
+    deps = setupDeps()
+    insertTeam(deps.db, "t1", "my-team", "lead-sess")
+    pt = new ProgressTracker()
+  })
+
+  function insertStalledMember(name: string, sessionId: string) {
+    insertMember(deps.db, "t1", name, sessionId, "busy", "running")
+    pt.recordBusyStart(sessionId)
+    // isTimeStalled's baseline is max(msgAt, taskAt, lastStepAt, busySince) — age the
+    // busySince entry directly so the member reads as stalled against a small threshold.
+    const busySince = (pt as unknown as { busySince: Map<string, number> }).busySince
+    busySince.set(sessionId, Date.now() - 10_000)
+  }
+
+  test("Fix 1: writes last_nudged_at on a successful nudge", async () => {
+    insertStalledMember("alice", "sess-a")
+    const watchdog = new Watchdog({
+      db: deps.db, client: deps.client, registry: deps.registry,
+      ttlMs: 0, progressTracker: pt, stallThresholdMs: 5_000,
+    })
+
+    const before = Date.now()
+    await watchdog.checkStalled()
+    // Flush the promptAsync().then() microtask.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    const row = deps.db.query("SELECT last_nudged_at FROM team_member WHERE name = 'alice'").get() as { last_nudged_at: number | null }
+    expect(row.last_nudged_at).not.toBeNull()
+    expect(row.last_nudged_at!).toBeGreaterThanOrEqual(before)
+  })
+
+  test("Fix 4: markReported is deferred until promptAsync delivery succeeds — a failed delivery does not orphan the stall state permanently", async () => {
+    insertStalledMember("alice", "sess-a")
+    let attempt = 0
+    const originalPromptAsync = deps.client.session.promptAsync.bind(deps.client.session)
+    deps.client.session.promptAsync = async (opts) => {
+      attempt++
+      if (attempt === 1) throw new Error("session aborted")
+      return originalPromptAsync(opts)
+    }
+
+    const watchdog = new Watchdog({
+      db: deps.db, client: deps.client, registry: deps.registry,
+      ttlMs: 0, progressTracker: pt, stallThresholdMs: 5_000,
+    })
+
+    await watchdog.checkStalled()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // Delivery failed — markReported must NOT have fired, so a later check can retry.
+    expect(pt.isReported("sess-a")).toBe(false)
+
+    deps.client.calls.length = 0
+    await watchdog.checkStalled()
+    const nudges = deps.client.calls.filter(c => c.method === "session.promptAsync")
+    expect(nudges).toHaveLength(1) // retried, not permanently orphaned
+    expect(attempt).toBe(2)
+  })
+
+  test("Fix 4: markReported fires after a successful delivery, preventing re-nudge on the next check", async () => {
+    insertStalledMember("alice", "sess-a")
+    const watchdog = new Watchdog({
+      db: deps.db, client: deps.client, registry: deps.registry,
+      ttlMs: 0, progressTracker: pt, stallThresholdMs: 5_000,
+    })
+
+    await watchdog.checkStalled()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(pt.isReported("sess-a")).toBe(true)
+
+    deps.client.calls.length = 0
+    await watchdog.checkStalled()
+    const nudges = deps.client.calls.filter(c => c.method === "session.promptAsync")
+    expect(nudges).toHaveLength(0) // already reported, no duplicate nudge
+  })
+
+  test("Fix 2: logs a structured failure when the stall nudge delivery fails", async () => {
+    insertStalledMember("alice", "sess-a")
+    deps.client.session.promptAsync = async () => { throw new Error("session aborted") }
+    const logCalls: string[] = []
+    ;(deps.client as unknown as { app: { log: (p: { message: string }) => Promise<unknown> } }).app = { log: async (p) => { logCalls.push(p.message); return {} } }
+    const { initLog } = await import("../src/log")
+    initLog(deps.client)
+
+    const watchdog = new Watchdog({
+      db: deps.db, client: deps.client, registry: deps.registry,
+      ttlMs: 0, progressTracker: pt, stallThresholdMs: 5_000,
+    })
+
+    await watchdog.checkStalled()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(logCalls.some(m => m.includes("alice") && m.includes("session aborted"))).toBe(true)
+  })
+
+  test("Fix 6: skips nudging a member who already reported completion, and logs the skip", async () => {
+    insertStalledMember("alice", "sess-a")
+    deps.db.run("UPDATE team_member SET reported_to_lead = 1 WHERE team_id = 't1' AND name = 'alice'")
+
+    const logCalls: string[] = []
+    ;(deps.client as unknown as { app: { log: (p: { message: string }) => Promise<unknown> } }).app = { log: async (p) => { logCalls.push(p.message); return {} } }
+    const { initLog } = await import("../src/log")
+    initLog(deps.client)
+
+    const watchdog = new Watchdog({
+      db: deps.db, client: deps.client, registry: deps.registry,
+      ttlMs: 0, progressTracker: pt, stallThresholdMs: 5_000,
+    })
+
+    await watchdog.checkStalled()
+
+    const nudges = deps.client.calls.filter(c => c.method === "session.promptAsync")
+    expect(nudges).toHaveLength(0)
+    expect(logCalls.some(m => m.includes("alice"))).toBe(true)
+  })
+
+  test("Fix 6: checkChatty skips nudging a member who already reported completion, and logs the skip", async () => {
+    insertMember(deps.db, "t1", "alice", "sess-a", "busy", "running")
+    deps.db.run("UPDATE team_member SET reported_to_lead = 1 WHERE team_id = 't1' AND name = 'alice'")
+    pt.recordPeerMessage("sess-a")
+    pt.recordPeerMessage("sess-a")
+
+    const logCalls: string[] = []
+    ;(deps.client as unknown as { app: { log: (p: { message: string }) => Promise<unknown> } }).app = { log: async (p) => { logCalls.push(p.message); return {} } }
+    const { initLog } = await import("../src/log")
+    initLog(deps.client)
+
+    const watchdog = new Watchdog({
+      db: deps.db, client: deps.client, registry: deps.registry,
+      ttlMs: 0, progressTracker: pt, peerMessageLimit: 2, peerMessageWindowMs: 300_000,
+    })
+
+    await watchdog.checkChatty()
+
+    const nudges = deps.client.calls.filter(c => c.method === "session.promptAsync")
+    expect(nudges).toHaveLength(0)
+    expect(logCalls.some(m => m.includes("alice"))).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

Six independent fixes found while stress-testing the teammate lifecycle under real, extended multi-teammate sessions: a re-engagement gap on completed teammates, two stall-detection gaps on a teammate's first action, an orphaned-team reconciliation gap plus a deadlock its own fix introduced, a false-success report from `team_merge`, and a missing chatty-detection wire on `team_broadcast`. Each was found via live reproduction against a real running server, not inferred from code reading alone — see the commit body for the fuller narrative on each.

### `team_message` cannot re-engage a teammate that already reported completion

The existing completion lock is correct behavior (prevents a courtesy-reply ping-pong loop) but had no deliberate override for legitimate follow-on work with the same teammate. Adds a lead-only `force: true` param that bypasses the lock; the existing busy-transition reset already handles clearing the flag afterward.

### Stall detection has zero coverage for a teammate's first action

`isTimeStalled` needs a prior step-finish event to establish a baseline, so a teammate blocked on its first long-running tool call is invisible to stall detection until the hard timeout. Fixed in two passes — wiring the busy-transition event, then discovering live that a freshly-spawned member never fires that transition at all (inserted directly as `busy`), requiring a second hook directly at spawn time.

### Orphaned-team reconciliation, and a deadlock its own fix introduced

A team with an externally-deleted lead session (deleted outside `team_cleanup`) stays `active` forever with no recovery path. Added a periodic sweep plus an on-demand check at `team_create`. The first version of this fix hung the whole server at init — its liveness check makes an HTTP call back to the same server before it's finished bootstrapping. Fixed with fire-and-forget dispatch plus a bounded timeout on the liveness check.

### `recoverStaleMembers`'s own pre-existing instance of the same deadlock class

Same deadlock shape, pre-existing in code this PR doesn't otherwise touch — awaited synchronously at init with an unbounded `session.abort()` call. Never fired in practice by coincidence, not design. Fixed with a bounded timeout, kept synchronous since a later init step depends on it.

### `team_merge` reports success when there was nothing to merge

A teammate that writes but never commits leaves a branch with zero new commits; `git merge --squash` against it is a no-op that reported success anyway. Now checks commit count first — zero commits + dirty worktree produces an explicit warning and leaves everything in place for manual recovery instead of silently losing the work.

### `team_broadcast` invisible to chatty-teammate detection

`team_message`'s handler feeds the chatty-detection rate limiter; `team_broadcast`'s never did, so the single most "chatty" action possible was invisible to it.

## Tests added

Coverage across `team-spawn`, `team-message`, `team-create`, `team-merge`, `recovery`, and `progress` — force re-engagement (and lead-only rejection), stall-baseline recording at both hook points, orphaned-team reconciliation via both the sweep and the on-demand path, fire-and-forget + timeout behavior for both deadlock-prone recovery passes, honest-vs-misleading `team_merge` reporting across zero-commit cases, and broadcast activity registering with chatty detection.

## Verification

- `bun run typecheck` — clean
- `bun test` — 715 pass, 0 fail
- `bun run build` — clean

Rebased onto current `main` (post `v0.16.1`/#30) — verified no interaction with the null-agent-spawn and task-claim-accuracy fixes in that release; all tests pass together.

Each fix was additionally live-reverified against a real running server and real spawned teammates reproducing the exact failure mode described above, not just against the added unit tests.

