### PR TITLE
feat(dashboard): version /api/state and expose leadSessionId for external consumers

### DIFF
--- a/src/dashboard-js-render.ts
+++ b/src/dashboard-js-render.ts
@@ -90,6 +90,7 @@ function rAgents(t){
       (mp?'<div class="mt-1 text-[12px] text-txt-400 truncate">Latest: '+E(mp)+'</div>':'')+
       '<div class="mt-2 flex items-center gap-1.5 flex-wrap">'+
         chip('status '+d,'muted')+chip('msg '+mi,'muted')+chip(E(m.executionStatus||m.status),m.status==='busy'?'blue':m.status==='error'?'red':'muted')+
+        (m.isRetrying?chip('retrying'+(m.retryAttempt!=null?' (attempt '+m.retryAttempt+')':''),'amber'):'')+
         (m.worktreeBranch?chip(E(m.worktreeBranch),'muted'):'')+
       '</div></button>';
   }).join('');
@@ -114,6 +115,7 @@ function openDrawer(name){
   if(m.planApproval&&m.planApproval!=='none')meta.push(chip(E(m.planApproval),m.planApproval==='approved'?'green':m.planApproval==='rejected'?'red':'amber'));
   meta.push(chip('spawned '+relT(m.timeCreated),'muted'));
   if(m.lastNudgedAt)meta.push(chip('nudged '+relT(m.lastNudgedAt),'amber'));
+  if(m.isRetrying)meta.push(chip('retrying'+(m.retryAttempt!=null?' (attempt '+m.retryAttempt+')':'')+(m.retryMessage?': '+E(m.retryMessage):''),'amber'));
   if(m.worktreeBranch)meta.push(chip(E(m.worktreeBranch),'muted'));
   h+='<div class="flex flex-wrap gap-1.5 mb-4 pb-4 border-b border-base-800/50">'+meta.join('')+'</div>';
   // Prompt

--- a/src/dashboard-js-render.ts
+++ b/src/dashboard-js-render.ts
@@ -81,7 +81,7 @@ function rAgents(t){
       '<div class="flex items-center gap-2">'+
         '<span class="w-[8px] h-[8px] rounded-full '+s.d+(m.status==='busy'?' pulse':'')+' shrink-0"></span>'+
         '<span class="font-mono font-semibold text-[14px] truncate">'+E(m.name)+'</span>'+
-        '<span class="text-[10px] px-1.5 py-[1px] rounded '+s.t+' bg-base-800/80 shrink-0">'+s.l+'</span>'+
+        '<span class="text-[10px] px-1.5 py-[1px] rounded '+s.t+' bg-base-800/80 shrink-0">'+s.l+(m.lastNudgedAt?', nudged '+relT(m.lastNudgedAt):'')+'</span>'+
         spark+
         '<span class="text-[10px] text-txt-500 ml-auto shrink-0">'+E(m.agent)+'</span>'+
         (m.model?chip(E(m.model),'muted'):'')+
@@ -113,6 +113,7 @@ function openDrawer(name){
   meta.push(chip(E(m.executionStatus||m.status),m.status==='busy'?'blue':m.status==='error'?'red':'muted'));
   if(m.planApproval&&m.planApproval!=='none')meta.push(chip(E(m.planApproval),m.planApproval==='approved'?'green':m.planApproval==='rejected'?'red':'amber'));
   meta.push(chip('spawned '+relT(m.timeCreated),'muted'));
+  if(m.lastNudgedAt)meta.push(chip('nudged '+relT(m.lastNudgedAt),'amber'));
   if(m.worktreeBranch)meta.push(chip(E(m.worktreeBranch),'muted'));
   h+='<div class="flex flex-wrap gap-1.5 mb-4 pb-4 border-b border-base-800/50">'+meta.join('')+'</div>';
   // Prompt

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -45,6 +45,10 @@ interface MemberRow {
   time_created: number
   time_updated: number
   last_nudged_at: number | null
+  retry_until: number | null
+  retry_attempt: number | null
+  retry_provider: string | null
+  retry_message: string | null
 }
 
 interface TaskRow {
@@ -107,7 +111,7 @@ export interface EnsembleDashboardState {
 function buildState(db: Database): EnsembleDashboardState {
   const projects = db.query("SELECT id, name, path, status, time_created, time_updated FROM project ORDER BY time_updated DESC").all() as ProjectRow[]
   const teams = db.query("SELECT id, name, project_id, lead_session_id, status, lead_agent, time_created, time_updated FROM team ORDER BY time_created DESC").all() as TeamRow[]
-  const memberStmt = db.query("SELECT name, agent, status, execution_status, session_id, worktree_branch, prompt, model, plan_approval, time_created, time_updated, last_nudged_at FROM team_member WHERE team_id = ?")
+  const memberStmt = db.query("SELECT name, agent, status, execution_status, session_id, worktree_branch, prompt, model, plan_approval, time_created, time_updated, last_nudged_at, retry_until, retry_attempt, retry_provider, retry_message FROM team_member WHERE team_id = ?")
   const taskStmt = db.query("SELECT id, content, status, priority, assignee, depends_on, time_created, time_updated FROM team_task WHERE team_id = ?")
   const msgStmt = db.query("SELECT id, from_name, to_name, content, delivered, read, time_created FROM team_message WHERE team_id = ? ORDER BY time_created DESC LIMIT 50")
 
@@ -125,6 +129,14 @@ function buildState(db: Database): EnsembleDashboardState {
       timeCreated: m.time_created,
       timeUpdated: m.time_updated,
       lastNudgedAt: m.last_nudged_at,
+      // Fix 4: derived, read-time TTL boolean (Fix 3) — never a stored enum.
+      // Additive fields; existing consumers that don't know about them simply
+      // don't render them.
+      isRetrying: m.retry_until !== null && m.retry_until > Date.now(),
+      retryUntil: m.retry_until,
+      retryAttempt: m.retry_attempt,
+      retryProvider: m.retry_provider,
+      retryMessage: m.retry_message,
     }))
     return {
       id: t.id,

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -81,7 +81,28 @@ function parseDependsOn(value: string | null): string[] {
   return []
 }
 
-function buildState(db: Database): { projects: unknown[]; teams: unknown[] } {
+/**
+ * Bare-integer version of the `/api/state` response shape. Bump on any
+ * breaking change to the payload (field removed/renamed/retyped, not
+ * additive fields). Consumers outside this repo compare this field with
+ * strict equality — no semver ranges. Currently consumed externally by the
+ * OpenCode sidebar TUI plugin that renders Team status from this endpoint.
+ */
+export const ENSEMBLE_STATE_VERSION = 1
+
+/**
+ * `/api/state` response shape. Exported and versioned because at least one
+ * consumer outside this repo (an OpenCode sidebar TUI plugin) polls this
+ * endpoint and depends on its shape. Treat additive-only changes as safe;
+ * bump {@link ENSEMBLE_STATE_VERSION} for anything else.
+ */
+export interface EnsembleDashboardState {
+  version: number
+  projects: unknown[]
+  teams: unknown[]
+}
+
+function buildState(db: Database): EnsembleDashboardState {
   const projects = db.query("SELECT id, name, path, status, time_created, time_updated FROM project ORDER BY time_updated DESC").all() as ProjectRow[]
   const teams = db.query("SELECT id, name, project_id, status, lead_agent, time_created, time_updated FROM team ORDER BY time_created DESC").all() as TeamRow[]
   const memberStmt = db.query("SELECT name, agent, status, execution_status, session_id, worktree_branch, prompt, model, plan_approval, time_created, time_updated FROM team_member WHERE team_id = ?")
@@ -140,6 +161,7 @@ function buildState(db: Database): { projects: unknown[]; teams: unknown[] } {
   })
 
   return {
+    version: ENSEMBLE_STATE_VERSION,
     projects: projects.flatMap(project => {
       const projectTeams = teamsByProject.get(project.id) ?? []
       if (projectTeams.length === 0) return []

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -16,6 +16,7 @@ interface TeamRow {
   id: string
   name: string
   project_id: string
+  lead_session_id: string
   status: string
   lead_agent: string | null
   time_created: number
@@ -104,7 +105,7 @@ export interface EnsembleDashboardState {
 
 function buildState(db: Database): EnsembleDashboardState {
   const projects = db.query("SELECT id, name, path, status, time_created, time_updated FROM project ORDER BY time_updated DESC").all() as ProjectRow[]
-  const teams = db.query("SELECT id, name, project_id, status, lead_agent, time_created, time_updated FROM team ORDER BY time_created DESC").all() as TeamRow[]
+  const teams = db.query("SELECT id, name, project_id, lead_session_id, status, lead_agent, time_created, time_updated FROM team ORDER BY time_created DESC").all() as TeamRow[]
   const memberStmt = db.query("SELECT name, agent, status, execution_status, session_id, worktree_branch, prompt, model, plan_approval, time_created, time_updated FROM team_member WHERE team_id = ?")
   const taskStmt = db.query("SELECT id, content, status, priority, assignee, depends_on, time_created, time_updated FROM team_task WHERE team_id = ?")
   const msgStmt = db.query("SELECT id, from_name, to_name, content, delivered, read, time_created FROM team_message WHERE team_id = ? ORDER BY time_created DESC LIMIT 50")
@@ -127,6 +128,7 @@ function buildState(db: Database): EnsembleDashboardState {
       id: t.id,
       name: t.name,
       projectId: t.project_id,
+      leadSessionId: t.lead_session_id,
       status: t.status,
       leadAgent: t.lead_agent,
       timeCreated: t.time_created,

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -44,6 +44,7 @@ interface MemberRow {
   plan_approval: string
   time_created: number
   time_updated: number
+  last_nudged_at: number | null
 }
 
 interface TaskRow {
@@ -106,7 +107,7 @@ export interface EnsembleDashboardState {
 function buildState(db: Database): EnsembleDashboardState {
   const projects = db.query("SELECT id, name, path, status, time_created, time_updated FROM project ORDER BY time_updated DESC").all() as ProjectRow[]
   const teams = db.query("SELECT id, name, project_id, lead_session_id, status, lead_agent, time_created, time_updated FROM team ORDER BY time_created DESC").all() as TeamRow[]
-  const memberStmt = db.query("SELECT name, agent, status, execution_status, session_id, worktree_branch, prompt, model, plan_approval, time_created, time_updated FROM team_member WHERE team_id = ?")
+  const memberStmt = db.query("SELECT name, agent, status, execution_status, session_id, worktree_branch, prompt, model, plan_approval, time_created, time_updated, last_nudged_at FROM team_member WHERE team_id = ?")
   const taskStmt = db.query("SELECT id, content, status, priority, assignee, depends_on, time_created, time_updated FROM team_task WHERE team_id = ?")
   const msgStmt = db.query("SELECT id, from_name, to_name, content, delivered, read, time_created FROM team_message WHERE team_id = ? ORDER BY time_created DESC LIMIT 50")
 
@@ -123,6 +124,7 @@ function buildState(db: Database): EnsembleDashboardState {
       planApproval: m.plan_approval,
       timeCreated: m.time_created,
       timeUpdated: m.time_updated,
+      lastNudgedAt: m.last_nudged_at,
     }))
     return {
       id: t.id,

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -26,7 +26,7 @@ function insertMessage(db: Database, teamId: string, id: string, fromName: strin
 // biome-lint: use Record for JSON response shape
 interface HealthResponse { ensemble: boolean; pid: number }
 interface DashboardTeam { id: string; name: string; projectId: string; status: string; timeCreated: number; timeUpdated: number; members: Array<{ sessionId?: string } & Record<string, unknown>>; tasks: Array<Record<string, unknown>>; messages: Array<Record<string, unknown>> }
-interface StateResponse { projects: Array<{ id: string; name: string; path: string; activeTeams: number; workingAgents: number; teams: DashboardTeam[] }>; teams: DashboardTeam[] }
+interface StateResponse { version: number; projects: Array<{ id: string; name: string; path: string; activeTeams: number; workingAgents: number; teams: DashboardTeam[] }>; teams: DashboardTeam[] }
 
 describe("dashboard", () => {
   let db: Database
@@ -63,7 +63,7 @@ describe("dashboard", () => {
       expect(res.status).toBe(200)
       expect(res.headers.get("access-control-allow-origin")).toBe("*")
       const body = (await res.json()) as StateResponse
-      expect(body).toEqual({ projects: [], teams: [] })
+      expect(body).toEqual({ version: 1, projects: [], teams: [] })
     })
 
     test("returns team with members, tasks, messages", async () => {
@@ -449,6 +449,18 @@ describe("dashboard", () => {
       const body = (await res.json()) as StateResponse
 
       expect(body.teams[0]!.members[0]!.sessionId).toBe("sess-a")
+    })
+  })
+
+  describe("state includes version", () => {
+    test("top-level response carries a bare-integer version field", async () => {
+      server = await startDashboard(db, port)
+      const res = await fetch(`http://localhost:${port}/api/state`)
+      const body = (await res.json()) as StateResponse & { version: number }
+
+      expect(typeof body.version).toBe("number")
+      expect(Number.isInteger(body.version)).toBe(true)
+      expect(body.version).toBe(1)
     })
   })
 

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -25,7 +25,7 @@ function insertMessage(db: Database, teamId: string, id: string, fromName: strin
 
 // biome-lint: use Record for JSON response shape
 interface HealthResponse { ensemble: boolean; pid: number }
-interface DashboardTeam { id: string; name: string; projectId: string; status: string; timeCreated: number; timeUpdated: number; members: Array<{ sessionId?: string } & Record<string, unknown>>; tasks: Array<Record<string, unknown>>; messages: Array<Record<string, unknown>> }
+interface DashboardTeam { id: string; name: string; projectId: string; leadSessionId?: string; status: string; timeCreated: number; timeUpdated: number; members: Array<{ sessionId?: string } & Record<string, unknown>>; tasks: Array<Record<string, unknown>>; messages: Array<Record<string, unknown>> }
 interface StateResponse { version: number; projects: Array<{ id: string; name: string; path: string; activeTeams: number; workingAgents: number; teams: DashboardTeam[] }>; teams: DashboardTeam[] }
 
 describe("dashboard", () => {
@@ -449,6 +449,22 @@ describe("dashboard", () => {
       const body = (await res.json()) as StateResponse
 
       expect(body.teams[0]!.members[0]!.sessionId).toBe("sess-a")
+    })
+  })
+
+  describe("state includes leadSessionId", () => {
+    test("team objects include leadSessionId, scoping to the session that created them", async () => {
+      insertTeam(db, "t1", "alpha", "lead-sess-a")
+      insertTeam(db, "t2", "beta", "lead-sess-b")
+
+      server = await startDashboard(db, port)
+      const res = await fetch(`http://localhost:${port}/api/state`)
+      const body = (await res.json()) as StateResponse
+
+      const teamA = body.teams.find((t) => t.id === "t1")
+      const teamB = body.teams.find((t) => t.id === "t2")
+      expect(teamA?.leadSessionId).toBe("lead-sess-a")
+      expect(teamB?.leadSessionId).toBe("lead-sess-b")
     })
   })
 

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -125,6 +125,66 @@ describe("dashboard", () => {
       expect(body.teams[0]!.members[0]!.lastNudgedAt).toBe(nudgedAt)
     })
 
+    test("Fix 4: exposes retry_* columns additively, with isRetrying derived at read time", async () => {
+      insertTeam(db, "t1", "alpha", "lead-sess")
+      insertMember(db, "t1", "alice", "sess-a", "busy", "running")
+      const futureRetryAt = Date.now() + 30_000
+      db.run(
+        "UPDATE team_member SET retry_until = ?, retry_attempt = ?, retry_provider = ?, retry_message = ? WHERE team_id = ? AND name = ?",
+        [futureRetryAt, 2, "anthropic", "Anthropic is currently overloaded", "t1", "alice"]
+      )
+
+      server = await startDashboard(db, port)
+      const res = await fetch(`http://localhost:${port}/api/state`)
+      const body = (await res.json()) as StateResponse
+      const member = body.teams[0]!.members[0]! as unknown as {
+        isRetrying: boolean; retryUntil: number; retryAttempt: number; retryProvider: string; retryMessage: string
+      }
+
+      expect(member.isRetrying).toBe(true)
+      expect(member.retryUntil).toBe(futureRetryAt)
+      expect(member.retryAttempt).toBe(2)
+      expect(member.retryProvider).toBe("anthropic")
+      expect(member.retryMessage).toBe("Anthropic is currently overloaded")
+    })
+
+    test("Fix 4/Fix 3: isRetrying reads false once retry_until has elapsed, with no explicit clear-write", async () => {
+      insertTeam(db, "t1", "alpha", "lead-sess")
+      insertMember(db, "t1", "alice", "sess-a", "busy", "running")
+      const pastRetryAt = Date.now() - 5000
+      db.run(
+        "UPDATE team_member SET retry_until = ?, retry_attempt = ?, retry_provider = ?, retry_message = ? WHERE team_id = ? AND name = ?",
+        [pastRetryAt, 1, "openai", "rate limited", "t1", "alice"]
+      )
+
+      server = await startDashboard(db, port)
+      const res = await fetch(`http://localhost:${port}/api/state`)
+      const body = (await res.json()) as StateResponse
+      const member = body.teams[0]!.members[0]! as unknown as { isRetrying: boolean; retryUntil: number }
+
+      // Column is untouched (no clear-write happened) but the derived boolean flipped.
+      expect(member.retryUntil).toBe(pastRetryAt)
+      expect(member.isRetrying).toBe(false)
+    })
+
+    test("Fix 4: retry fields are null/false for a member that has never retried", async () => {
+      insertTeam(db, "t1", "alpha", "lead-sess")
+      insertMember(db, "t1", "alice", "sess-a", "busy", "running")
+
+      server = await startDashboard(db, port)
+      const res = await fetch(`http://localhost:${port}/api/state`)
+      const body = (await res.json()) as StateResponse
+      const member = body.teams[0]!.members[0]! as unknown as {
+        isRetrying: boolean; retryUntil: number | null; retryAttempt: number | null; retryProvider: string | null; retryMessage: string | null
+      }
+
+      expect(member.isRetrying).toBe(false)
+      expect(member.retryUntil).toBeNull()
+      expect(member.retryAttempt).toBeNull()
+      expect(member.retryProvider).toBeNull()
+      expect(member.retryMessage).toBeNull()
+    })
+
     test("summarizes progress across projects", async () => {
       insertTeam(db, "t1", "alpha", "lead-1")
       db.run("INSERT OR IGNORE INTO project (id, name, path, status, time_created, time_updated) VALUES (?, ?, ?, 'active', ?, ?)", ["/tmp/project-a", "project-a", "/tmp/project-a", Date.now(), Date.now()])

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -90,6 +90,7 @@ describe("dashboard", () => {
       expect(team.members[0]!.agent).toBe("build")
       expect(team.members[0]!.status).toBe("busy")
       expect(team.members[0]!.executionStatus).toBe("running")
+      expect(team.members[0]!.lastNudgedAt).toBeNull()
 
       expect(team.tasks).toHaveLength(1)
       expect(team.tasks[0]!.id).toBe("task-1")
@@ -109,6 +110,19 @@ describe("dashboard", () => {
       expect(body.projects[0]!.activeTeams).toBe(1)
       expect(body.projects[0]!.workingAgents).toBe(1)
       expect(body.projects[0]!.teams[0]!.id).toBe("t1")
+    })
+
+    test("Fix 1: exposes last_nudged_at as an additive lastNudgedAt field", async () => {
+      insertTeam(db, "t1", "alpha", "lead-sess")
+      insertMember(db, "t1", "alice", "sess-a", "busy", "running")
+      const nudgedAt = Date.now() - 5000
+      db.run("UPDATE team_member SET last_nudged_at = ? WHERE team_id = ? AND name = ?", [nudgedAt, "t1", "alice"])
+
+      server = await startDashboard(db, port)
+      const res = await fetch(`http://localhost:${port}/api/state`)
+      const body = (await res.json()) as StateResponse
+
+      expect(body.teams[0]!.members[0]!.lastNudgedAt).toBe(nudgedAt)
     })
 
     test("summarizes progress across projects", async () => {


### PR DESCRIPTION
## Summary
Types and versions the `/api/state` dashboard endpoint's response shape, and exposes each team's `lead_session_id` (already stored in the DB, never selected before). Both are additive-only changes motivated by an external consumer — an OpenCode sidebar TUI plugin that polls this endpoint to show live team/agent status — needing a stable contract to detect payload drift instead of crashing or rendering stale data, and a way to scope teams to the session that created them rather than showing every team ever tracked.

## Changes
- `buildState()`'s return type is now the exported, documented `EnsembleDashboardState` interface instead of an inline `{ projects: unknown[]; teams: unknown[] }` shape.
- `/api/state` now returns a bare-integer `version` field (`ENSEMBLE_STATE_VERSION`, currently `1`). Bump on any breaking change to the payload; additive fields don't require a bump.
- Each team object now includes `leadSessionId` alongside the existing `leadAgent`.
- No behavior changes to teammate lifecycle, dashboard rendering, or any existing endpoint.

## Test Plan
- [x] Two new tests: version field shape, leadSessionId presence per team
- [x] Full suite: 695 pass, 0 fail
- [x] `bun run typecheck`: clean